### PR TITLE
Install required dependencies when using the Goth generator

### DIFF
--- a/buffalo/cmd/generate/goth.go
+++ b/buffalo/cmd/generate/goth.go
@@ -46,6 +46,8 @@ var GothCmd = &cobra.Command{
 func NewGothGenerator() *gentronics.Generator {
 	g := gentronics.New()
 	g.Add(gentronics.NewFile(filepath.Join("actions", "goth.go"), gGoth))
+	g.Add(gentronics.NewCommand(GoGet("github.com/markbates/goth")))
+	g.Add(gentronics.NewCommand(GoGet("github.com/mrjones/oauth")))
 	g.Add(Fmt)
 	return g
 }


### PR DESCRIPTION
This PR updates the goth generator (now that #74 is merged) to use go get to install the two required dependencies `github.com/markbates/goth` and `github.com/mrjones/oauth`

Fixes #75 