### PR TITLE
Avoiding generating log folder when running tests.

### DIFF
--- a/options.go
+++ b/options.go
@@ -43,8 +43,14 @@ func NewOptions() Options {
 func optionsWithDefaults(opts Options) Options {
 	opts.Env = defaults.String(opts.Env, defaults.String(os.Getenv("GO_ENV"), "development"))
 	opts.LogLevel = defaults.String(opts.LogLevel, "debug")
-	pwd, _ := os.Getwd()
-	opts.LogDir = defaults.String(opts.LogDir, filepath.Join(pwd, "logs"))
+
+	if opts.Env == "test" {
+		opts.LogDir = os.TempDir()
+	} else {
+		pwd, _ := os.Getwd()
+		opts.LogDir = defaults.String(opts.LogDir, filepath.Join(pwd, "logs"))
+	}
+
 	if opts.SessionStore == nil {
 		opts.SessionStore = sessions.NewCookieStore([]byte(os.Getenv("SESSION_SECRET")))
 	}

--- a/options.go
+++ b/options.go
@@ -44,11 +44,11 @@ func optionsWithDefaults(opts Options) Options {
 	opts.Env = defaults.String(opts.Env, defaults.String(os.Getenv("GO_ENV"), "development"))
 	opts.LogLevel = defaults.String(opts.LogLevel, "debug")
 
+	pwd, _ := os.Getwd()
+	opts.LogDir = defaults.String(opts.LogDir, filepath.Join(pwd, "logs"))
+
 	if opts.Env == "test" {
 		opts.LogDir = os.TempDir()
-	} else {
-		pwd, _ := os.Getwd()
-		opts.LogDir = defaults.String(opts.LogDir, filepath.Join(pwd, "logs"))
 	}
 
 	if opts.SessionStore == nil {


### PR DESCRIPTION
This is related to #17.

cc: @markbates.