### PR TITLE
Makes our tests run on Go 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
 env:
   matrix:
     - GO_DOCKER_TAG=1.7
-    - GO_DOCKER_TAG=latest
+    - GO_DOCKER_TAG=1.8
 
 script:
   - perl -pi -w -e "s/{{GO_DOCKER_TAG}}/$GO_DOCKER_TAG/g" Dockerfile && docker build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - GO_DOCKER_TAG=1.8
 
 script:
-  - perl -pi -w -e "s/FROM golang:1.7/FROM golang:$GO_DOCKER_TAG/g" Dockerfile && docker build .
+  - perl -pi -w -e "s/FROM golang:latest/FROM golang:$GO_DOCKER_TAG/g" Dockerfile && docker build .
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,18 @@ sudo: required
 
 services:
   - docker
-
-language: go
+install: false
 
 go:
   - 1.7
-  - master
+
+env:
+  matrix:
+    - GO_DOCKER_TAG=1.7
+    - GO_DOCKER_TAG=latest
 
 script:
-  - docker build .
+  - perl -pi -w -e "s/{{GO_DOCKER_TAG}}/$GO_DOCKER_TAG/g" Dockerfile && docker build .
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - GO_DOCKER_TAG=1.8
 
 script:
-  - perl -pi -w -e "s/{{GO_DOCKER_TAG}}/$GO_DOCKER_TAG/g" Dockerfile && docker build .
+  - perl -pi -w -e "s/FROM golang:1.7/FROM golang:$GO_DOCKER_TAG/g" Dockerfile && docker build .
 
 addons:
   code_climate:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:{{GO_DOCKER_TAG}}
 
 RUN apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.7
+FROM golang:latest
+
+RUN go version
 
 RUN apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:{{GO_DOCKER_TAG}}
+FROM golang:1.7
 
 RUN apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash


### PR DESCRIPTION
@markbates This PR makes our tests run against Go`1.7` and `1.8` you may notice i set it to be `1.8` instead of `latest` because on the [dockerhub](https://hub.docker.com/_/golang/) latest is 1.7.4 or latest stable.

