### PR TITLE
import buffalo when generating a new action

### DIFF
--- a/buffalo/cmd/generate/action.go
+++ b/buffalo/cmd/generate/action.go
@@ -56,7 +56,7 @@ var ActionCmd = &cobra.Command{
 }
 
 func buildActionsTemplate(filePath string) string {
-	actionsTemplate := "package actions"
+	actionsTemplate := rActionFileT
 	fileContents, err := ioutil.ReadFile(filePath)
 	if err == nil {
 		actionsTemplate = string(fileContents)

--- a/buffalo/cmd/generate/action_test.go
+++ b/buffalo/cmd/generate/action_test.go
@@ -57,6 +57,8 @@ func TestGenerateActionActionsFolderExists(t *testing.T) {
 	r.Nil(e)
 
 	data, _ := ioutil.ReadFile("actions/users.go")
+	r.Contains(string(data), "package actions")
+	r.Contains(string(data), `import "github.com/gobuffalo/buffalo"`)
 	r.Contains(string(data), "func UsersShow(c buffalo.Context) error {")
 	r.Contains(string(data), "func UsersEdit(c buffalo.Context) error {")
 	r.Contains(string(data), `r.HTML("users/edit.html")`)


### PR DESCRIPTION
The current action generator does not import buffalo, and the resultant actions will fail to compile.  This PR adds a quick fix and test.