### PR TITLE
preventing wrapping errors with point in error handler stack

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -51,7 +51,6 @@ func defaultErrorHandler(status int, err error, c Context) error {
 		c.Response().Write([]byte(prodErrorTmpl))
 		return nil
 	}
-	err = errors.WithStack(err)
 	c.Logger().Error(err)
 	c.Response().WriteHeader(status)
 


### PR DESCRIPTION
This PR removes an extra errors.WithStack call which will wrap all errors handled by the defaultErrorHandler with the following stack trace.  As this occurs for every defaultErrorHandler invocation in dev, and is formatted as if it was part of the primary stack trace it may be useful to remove this wrap.

> github.com/gobuffalo/buffalo.defaultErrorHandler
	/Users/lumost/src/github.com/gobuffalo/buffalo/errors.go:54
github.com/gobuffalo/buffalo.(*App).handlerToHandler.func1
	/Users/lumost/src/github.com/gobuffalo/buffalo/handler.go:63
net/http.HandlerFunc.ServeHTTP
	/usr/local/Cellar/go/1.7.4_1/libexec/src/net/http/server.go:1726
github.com/gorilla/mux.(*Router).ServeHTTP
	/Users/lumost/src/github.com/gorilla/mux/mux.go:114
github.com/markbates/refresh/refresh/web.ErrorChecker.func1
	/Users/lumost/src/github.com/markbates/refresh/refresh/web/web.go:23
net/http.HandlerFunc.ServeHTTP
	/usr/local/Cellar/go/1.7.4_1/libexec/src/net/http/server.go:1726
github.com/gobuffalo/buffalo.(*App).ServeHTTP
	/Users/lumost/src/github.com/gobuffalo/buffalo/app.go:44
net/http.serverHandler.ServeHTTP
	/usr/local/Cellar/go/1.7.4_1/libexec/src/net/http/server.go:2202
net/http.(*conn).serve
	/usr/local/Cellar/go/1.7.4_1/libexec/src/net/http/server.go:1579
runtime.goexit
	/usr/local/Cellar/go/1.7.4_1/libexec/src/runtime/asm_amd64.s:2086
