### PR TITLE
UnWrap HttpErrors in pop middleware and return them.

### DIFF
--- a/default_context.go
+++ b/default_context.go
@@ -103,13 +103,13 @@ func (d *DefaultContext) Render(status int, rr render.Renderer) error {
 		bb := &bytes.Buffer{}
 		err := rr.Render(bb, data)
 		if err != nil {
-			return httpError{Status: 500, Cause: errors.WithStack(err)}
+			return HttpError{Status: 500, Cause: errors.WithStack(err)}
 		}
 		d.Response().Header().Set("Content-Type", rr.ContentType())
 		d.Response().WriteHeader(status)
 		_, err = io.Copy(d.Response(), bb)
 		if err != nil {
-			return httpError{Status: 500, Cause: errors.WithStack(err)}
+			return HttpError{Status: 500, Cause: errors.WithStack(err)}
 		}
 		return nil
 	}
@@ -155,7 +155,7 @@ func (d *DefaultContext) LogFields(values map[string]interface{}) {
 }
 
 func (d *DefaultContext) Error(status int, err error) error {
-	return httpError{Status: status, Cause: errors.WithStack(err)}
+	return HttpError{Status: status, Cause: errors.WithStack(err)}
 }
 
 // Websocket returns an upgraded github.com/gorilla/websocket.Conn

--- a/default_context.go
+++ b/default_context.go
@@ -103,13 +103,13 @@ func (d *DefaultContext) Render(status int, rr render.Renderer) error {
 		bb := &bytes.Buffer{}
 		err := rr.Render(bb, data)
 		if err != nil {
-			return HttpError{Status: 500, Cause: errors.WithStack(err)}
+			return HTTPError{Status: 500, Cause: errors.WithStack(err)}
 		}
 		d.Response().Header().Set("Content-Type", rr.ContentType())
 		d.Response().WriteHeader(status)
 		_, err = io.Copy(d.Response(), bb)
 		if err != nil {
-			return HttpError{Status: 500, Cause: errors.WithStack(err)}
+			return HTTPError{Status: 500, Cause: errors.WithStack(err)}
 		}
 		return nil
 	}
@@ -155,7 +155,7 @@ func (d *DefaultContext) LogFields(values map[string]interface{}) {
 }
 
 func (d *DefaultContext) Error(status int, err error) error {
-	return HttpError{Status: status, Cause: errors.WithStack(err)}
+	return HTTPError{Status: status, Cause: errors.WithStack(err)}
 }
 
 // Websocket returns an upgraded github.com/gorilla/websocket.Conn

--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// A typed error returned by http Handlers and used for choosing error handlers
+// HTTPError a typed error returned by http Handlers and used for choosing error handlers
 type HTTPError struct {
 	Status int   `json:"status"`
 	Cause  error `json:"error"`

--- a/errors.go
+++ b/errors.go
@@ -52,7 +52,6 @@ func defaultErrorHandler(status int, err error, c Context) error {
 		c.Response().Write([]byte(prodErrorTmpl))
 		return nil
 	}
-	err = errors.WithStack(err)
 	c.Logger().Error(err)
 	c.Response().WriteHeader(status)
 

--- a/errors.go
+++ b/errors.go
@@ -9,12 +9,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-type httpError struct {
+type HttpError struct {
 	Status int   `json:"status"`
 	Cause  error `json:"error"`
 }
 
-func (h httpError) Error() string {
+func (h HttpError) Error() string {
 	return h.Cause.Error()
 }
 
@@ -51,6 +51,7 @@ func defaultErrorHandler(status int, err error, c Context) error {
 		c.Response().Write([]byte(prodErrorTmpl))
 		return nil
 	}
+	err = errors.WithStack(err)
 	c.Logger().Error(err)
 	c.Response().WriteHeader(status)
 

--- a/errors.go
+++ b/errors.go
@@ -9,12 +9,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-type HttpError struct {
+type HTTPError struct {
 	Status int   `json:"status"`
 	Cause  error `json:"error"`
 }
 
-func (h HttpError) Error() string {
+func (h HTTPError) Error() string {
 	return h.Cause.Error()
 }
 

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// A typed error returned by http Handlers and used for choosing error handlers
 type HTTPError struct {
 	Status int   `json:"status"`
 	Cause  error `json:"error"`

--- a/handler.go
+++ b/handler.go
@@ -56,7 +56,7 @@ func (a *App) handlerToHandler(info RouteInfo, h Handler) http.Handler {
 
 		if err != nil {
 			status := 500
-			if e, ok := err.(HttpError); ok {
+			if e, ok := err.(HTTPError); ok {
 				status = e.Status
 			}
 			eh := a.ErrorHandlers.Get(status)

--- a/handler.go
+++ b/handler.go
@@ -56,7 +56,7 @@ func (a *App) handlerToHandler(info RouteInfo, h Handler) http.Handler {
 
 		if err != nil {
 			status := 500
-			if e, ok := err.(httpError); ok {
+			if e, ok := err.(HttpError); ok {
 				status = e.Status
 			}
 			eh := a.ErrorHandlers.Get(status)

--- a/handler.go
+++ b/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 // Handler is the basis for all of Buffalo. A Handler
@@ -56,8 +57,11 @@ func (a *App) handlerToHandler(info RouteInfo, h Handler) http.Handler {
 
 		if err != nil {
 			status := 500
-			if e, ok := err.(HTTPError); ok {
-				status = e.Status
+			// unpack root cause and check for HTTPError
+			cause := errors.Cause(err)
+			httpError, ok := cause.(HTTPError)
+			if ok {
+				status = httpError.Status
 			}
 			eh := a.ErrorHandlers.Get(status)
 			err = eh(status, err, c)

--- a/middleware/pop_transaction.go
+++ b/middleware/pop_transaction.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/markbates/pop"
+	"github.com/pkg/errors"
 )
 
 // PopTransaction is a piece of Buffalo middleware that wraps each
@@ -30,7 +31,7 @@ var PopTransaction = func(db *pop.Connection) buffalo.MiddlewareFunc {
 			})
 			// find out if there is an underlying http error and return it rather than returning
 			// the wrapped transaction error
-			switch rootCause := err.Cause().(type) {
+			switch rootCause := errors.Cause(err).(type) {
 			case buffalo.HTTPError:
 				return rootCause
 			default:

--- a/middleware/pop_transaction.go
+++ b/middleware/pop_transaction.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/markbates/pop"
-	"github.com/pkg/errors"
 )
 
 // PopTransaction is a piece of Buffalo middleware that wraps each
@@ -18,8 +17,7 @@ var PopTransaction = func(db *pop.Connection) buffalo.MiddlewareFunc {
 		return func(c buffalo.Context) error {
 			// wrap all requests in a transaction and set the length
 			// of time doing things in the db to the log.
-
-			err := db.Transaction(func(tx *pop.Connection) error {
+			return db.Transaction(func(tx *pop.Connection) error {
 				start := tx.Elapsed
 				defer func() {
 					finished := tx.Elapsed
@@ -29,14 +27,6 @@ var PopTransaction = func(db *pop.Connection) buffalo.MiddlewareFunc {
 				c.Set("tx", tx)
 				return h(c)
 			})
-			// find out if there is an underlying http error and return it rather than returning
-			// the wrapped transaction error
-			switch rootCause := errors.Cause(err).(type) {
-			case buffalo.HTTPError:
-				return rootCause
-			default:
-				return err
-			}
 		}
 	}
 }

--- a/middleware/pop_transaction.go
+++ b/middleware/pop_transaction.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/markbates/pop"
-	"github.com/pkg/errors"
 )
 
 // PopTransaction is a piece of Buffalo middleware that wraps each
@@ -31,8 +30,8 @@ var PopTransaction = func(db *pop.Connection) buffalo.MiddlewareFunc {
 			})
 			// find out if there is an underlying http error and return it rather than returning
 			// the wrapped transaction error
-			switch rootCause := errors.Cause(err).(type) {
-			case buffalo.HttpError:
+			switch rootCause := err.Cause().(type) {
+			case buffalo.HTTPError:
 				return rootCause
 			default:
 				return err

--- a/middleware/pop_transaction.go
+++ b/middleware/pop_transaction.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/markbates/pop"
+	"github.com/pkg/errors"
 )
 
 // PopTransaction is a piece of Buffalo middleware that wraps each
@@ -17,7 +18,8 @@ var PopTransaction = func(db *pop.Connection) buffalo.MiddlewareFunc {
 		return func(c buffalo.Context) error {
 			// wrap all requests in a transaction and set the length
 			// of time doing things in the db to the log.
-			return db.Transaction(func(tx *pop.Connection) error {
+
+			err := db.Transaction(func(tx *pop.Connection) error {
 				start := tx.Elapsed
 				defer func() {
 					finished := tx.Elapsed
@@ -27,6 +29,14 @@ var PopTransaction = func(db *pop.Connection) buffalo.MiddlewareFunc {
 				c.Set("tx", tx)
 				return h(c)
 			})
+			// find out if there is an underlying http error and return it rather than returning
+			// the wrapped transaction error
+			switch rootCause := errors.Cause(err).(type) {
+			case buffalo.HttpError:
+				return rootCause
+			default:
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
The pop transaction middleware wraps all handlers in a connection.Transaction, which in turn wraps any errors the handler emits.  The default ErrorHandler will then handle the error as a 500 and will not be able to mirror the requested status from a call such as `c.Error(401, err)`