### PR TITLE
Fix rendering if alternative layout is used

### DIFF
--- a/render/html.go
+++ b/render/html.go
@@ -27,7 +27,7 @@ func (e *Engine) HTML(names ...string) Renderer {
 	hr := templateRenderer{
 		Engine:      e,
 		contentType: "text/html",
-		names:       names,
+		names:       names[:2],
 	}
 	return hr
 }


### PR DESCRIPTION
If an HTMLLayout was already set and an altenative layout specified
this would be rendered as well resulting in a webpage with multiple
<html>...</html> sections.