### PR TITLE
Skipping test generation if test exists on action generation

### DIFF
--- a/buffalo/cmd/generate/action.go
+++ b/buffalo/cmd/generate/action.go
@@ -42,7 +42,10 @@ var ActionCmd = &cobra.Command{
 		testFilePath := filepath.Join("actions", fmt.Sprintf("%v_test.go", data["filename"]))
 		testsTemplate := buildTestsTemplate(testFilePath)
 		actionsToAdd := findActionsToAdd(name, filePath, actions)
+		testsToAdd := findTestsToAdd(name, testFilePath, actions)
+
 		data["actions"] = actionsToAdd
+		data["tests"] = testsToAdd
 
 		g := gentronics.New()
 		g.Add(gentronics.NewFile(filepath.Join("actions", fmt.Sprintf("%s.go", data["filename"])), actionsTemplate))
@@ -85,14 +88,14 @@ func {{namespace}}{{camelize action}}(c buffalo.Context) error {
 }
 
 func buildTestsTemplate(filePath string) string {
-	testsTemplate := rTestFileT
+	testsTemplate := `package actions`
 	fileContents, err := ioutil.ReadFile(filePath)
 	if err == nil {
 		testsTemplate = string(fileContents)
 	}
 
 	testsTemplate = testsTemplate + `
-{{#each actions as |action|}}
+{{#each tests as |action|}}
 func Test_{{namespace}}_{{camelize action}}(t *testing.T) {
 	r := require.New(t)
 	r.Fail("Not Implemented!")
@@ -135,6 +138,27 @@ func findActionsToAdd(name, path string, actions []string) []string {
 	return actionsToAdd
 }
 
+func findTestsToAdd(name, path string, actions []string) []string {
+	fileContents, err := ioutil.ReadFile(path)
+	if err != nil {
+		fileContents = []byte("")
+	}
+
+	actionsToAdd := []string{}
+
+	for _, action := range actions {
+		funcSignature := fmt.Sprintf("func Test_%v_%v(c buffalo.Context) error", inflect.Camelize(name), inflect.Camelize(action))
+		if strings.Contains(string(fileContents), funcSignature) {
+			fmt.Printf("--> [warning] skipping Test_%v_%v since it already exists\n", inflect.Camelize(name), inflect.Camelize(action))
+			continue
+		}
+
+		actionsToAdd = append(actionsToAdd, action)
+	}
+
+	return actionsToAdd
+}
+
 const (
 	rActionFileT = `package actions
 import "github.com/gobuffalo/buffalo"`
@@ -144,15 +168,6 @@ import "github.com/gobuffalo/buffalo"`
 // {{namespace}}{{action}} default implementation.
 func {{namespace}}{{action}}(c buffalo.Context) error {
 	return c.Render(200, r.HTML("{{namespace_under}}/{{action_under}}.html"))
-}
-`
-
-	rTestFileT = `package actions_test
-	`
-	rTestFuncT = `
-func Test_{{namespace}}_{{camelize action}}(t *testing.T) {
-	r := require.New(t)
-	r.Fail("Not Implemented!")
 }
 `
 )

--- a/buffalo/cmd/generate/action_test.go
+++ b/buffalo/cmd/generate/action_test.go
@@ -139,7 +139,7 @@ func TestGenerateNewActionWithExistingActions(t *testing.T) {
 	r.Contains(string(data), "<h1>Users#List</h1>")
 
 	data, _ = ioutil.ReadFile("actions/users_test.go")
-	r.Contains(string(data), "package actions_test")
+	r.Contains(string(data), "package actions")
 	r.Contains(string(data), "func Test_Users_Show(t *testing.T) {")
 	r.Contains(string(data), "func Test_Users_Edit(t *testing.T) {")
 	r.Contains(string(data), "func Test_Users_List(t *testing.T) {")


### PR DESCRIPTION
After #175 i noticed buffalo were also generating a test case for existing tests, this PR makes the action generator skip those tests.

cc @markbates @stanislas-m