### PR TITLE
fixes #183

### DIFF
--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -78,12 +78,7 @@ var newCmd = &cobra.Command{
 }
 
 func validDbType() bool {
-	switch dbType {
-	case "postgres", "mysql", "sqlite3":
-		return true
-	default:
-		return false
-	}
+	return dbType == "postgres" || dbType == "mysql" || dbType == "sqlite3"
 }
 
 func validateInGoPath(name string) error {

--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -44,6 +44,10 @@ var newCmd = &cobra.Command{
 	Use:   "new [name]",
 	Short: "Creates a new Buffalo application",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !validDbType() {
+			return fmt.Errorf("Unknown db-type %s expecting one of postgres, mysql or sqlite3", dbType)
+		}
+
 		if len(args) == 0 {
 			return errors.New("you must enter a name for your new application")
 		}
@@ -71,6 +75,15 @@ var newCmd = &cobra.Command{
 
 		return genNewFiles(name, rootPath)
 	},
+}
+
+func validDbType() bool {
+	switch dbType {
+	case "postgres", "mysql", "sqlite3":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateInGoPath(name string) error {

--- a/buffalo/cmd/root.go
+++ b/buffalo/cmd/root.go
@@ -44,7 +44,6 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(-1)
 	}
 }

--- a/buffalo/cmd/soda_generators.go
+++ b/buffalo/cmd/soda_generators.go
@@ -31,8 +31,7 @@ func newSodaGenerator() *gentronics.Generator {
 		Should: should,
 		Runner: func(rootPath string, data gentronics.Data) error {
 			data["dialect"] = data["dbType"]
-			generate.GenerateConfig("./database.yml", data)
-			return nil
+			return generate.GenerateConfig("./database.yml", data)
 		},
 	})
 


### PR DESCRIPTION
Fixes the silent failing of a unknown db-type. The following is the result.

```
buffalo new coke --db-type SOMETHING-BAD!

Buffalo version 0.7.1

Error: Unknown db-type SOMETHING-BAD! expecting one of postgres, mysql or sqlite3
Usage:
  buffalo new [name] [flags]

Flags:
      --db-type string   specify the type of database you want to use [postgres, mysql, sqlite3] (default "postgres")
  -f, --force            delete and remake if the app already exists
      --skip-pop         skips adding pop/soda to your app
      --skip-webpack     skips adding Webpack to your app
  -v, --verbose          verbosely print out the go get/install commands
```