### PR TITLE
[#198] moving resource generator to avoid pointers

### DIFF
--- a/buffalo/cmd/generate/resource.go
+++ b/buffalo/cmd/generate/resource.go
@@ -80,7 +80,7 @@ type {{camel}}Resource struct{
 
 {{#each actions}}
 // {{.}} default implementation.
-func (v *{{camel}}Resource) {{.}}(c buffalo.Context) error {
+func (v {{camel}}Resource) {{.}}(c buffalo.Context) error {
 	return c.Render(200, r.String("{{camel}}#{{.}}"))
 }
 

--- a/buffalo/cmd/generate/resource.go
+++ b/buffalo/cmd/generate/resource.go
@@ -62,7 +62,7 @@ func NewResourceGenerator(data gentronics.Data) *gentronics.Generator {
 		Should: func(data gentronics.Data) bool { return true },
 		Runner: func(root string, data gentronics.Data) error {
 			return addInsideAppBlock(fmt.Sprintf("var %sResource buffalo.Resource", data["downFirstCap"]),
-				fmt.Sprintf("%sResource = &%sResource{&buffalo.BaseResource{}}", data["downFirstCap"], data["camel"]),
+				fmt.Sprintf("%sResource = %sResource{&buffalo.BaseResource{}}", data["downFirstCap"], data["camel"]),
 				fmt.Sprintf("app.Resource(\"/%s\", %sResource)", data["under"], data["downFirstCap"]),
 			)
 		},

--- a/buffalo/cmd/generate/resource_test.go
+++ b/buffalo/cmd/generate/resource_test.go
@@ -34,13 +34,13 @@ func TestGenerateResourceCode(t *testing.T) {
 
 	fileData, _ := ioutil.ReadFile("actions/app.go")
 	r.Contains(string(fileData), "var usersResource buffalo.Resource")
-	r.Contains(string(fileData), "usersResource = &UsersResource{&buffalo.BaseResource{}}")
+	r.Contains(string(fileData), "usersResource = UsersResource{&buffalo.BaseResource{}}")
 	r.Contains(string(fileData), "app.Resource(\"/users\", usersResource)")
 
 	fileData, _ = ioutil.ReadFile("actions/users.go")
 	r.Contains(string(fileData), "type UsersResource struct {")
-	r.Contains(string(fileData), "func (v *UsersResource) List(c buffalo.Context) error {")
-	r.Contains(string(fileData), "func (v *UsersResource) Destroy(c buffalo.Context) error {")
+	r.Contains(string(fileData), "func (v UsersResource) List(c buffalo.Context) error {")
+	r.Contains(string(fileData), "func (v UsersResource) Destroy(c buffalo.Context) error {")
 
 	fileData, _ = ioutil.ReadFile("actions/users_test.go")
 	r.Contains(string(fileData), "func Test_UsersResource_List")


### PR DESCRIPTION
Avoids using pointers for generated resource functions.
cc @markbates 