### PR TITLE
Update usage of validate in html-crud example

### DIFF
--- a/examples/html-crud/models/user.go
+++ b/examples/html-crud/models/user.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/markbates/going/validate"
-	"github.com/markbates/going/validate/validators"
 	"github.com/markbates/pop"
+	"github.com/markbates/validate"
+	"github.com/markbates/validate/validators"
 )
 
 // User model stores information about a user account


### PR DESCRIPTION
As of
https://github.com/markbates/going/commit/b92cf13751e567d869239b59e29dda92009a610b
`validate`, which is used in the model layer, got moved from
https://github.com/markbates/going to https://github.com/markbates/validate

This change updates the `User` model to use the proper updated packages

Thanks!