### PR TITLE
Remove commented code in cmd/root.go

### DIFF
--- a/buffalo/cmd/root.go
+++ b/buffalo/cmd/root.go
@@ -37,23 +37,3 @@ func goInstall(pkg string) *exec.Cmd {
 func goGet(pkg string) *exec.Cmd {
 	return generate.GoGet(pkg)
 }
-
-// func init() {
-// cobra.OnInitialize(initConfig)
-// RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.buffalo.yaml)")
-// }
-
-// func initConfig() {
-// 	if cfgFile != "" { // enable ability to specify config file via flag
-// 		viper.SetConfigFile(cfgFile)
-// 	}
-//
-// 	viper.SetConfigName(".buffalo") // name of config file (without extension)
-// 	viper.AddConfigPath("$HOME")    // adding home directory as first search path
-// 	viper.AutomaticEnv()            // read in environment variables that match
-//
-// 	// If a config file is found, read it in.
-// 	if err := viper.ReadInConfig(); err == nil {
-// 		fmt.Println("Using config file:", viper.ConfigFileUsed())
-// 	}
-// }


### PR DESCRIPTION
This code was commented out in
https://github.com/gobuffalo/buffalo/commit/c72b52927fa7e170d369edac182b382cea6f39a3
and it seems unused.

Thanks!