### PR TITLE
Allow go get build flags (will be useful with soda generators).

### DIFF
--- a/buffalo/cmd/generate/gocmd.go
+++ b/buffalo/cmd/generate/gocmd.go
@@ -10,8 +10,9 @@ func GoInstall(pkg string) *exec.Cmd {
 }
 
 // GoGet downloads and installs packages and dependencies
-func GoGet(pkg string) *exec.Cmd {
+func GoGet(pkg string, buildFlags ...string) *exec.Cmd {
 	args := []string{"get"}
 	args = append(args, pkg)
+	args = append(args, buildFlags...)
 	return exec.Command("go", args...)
 }

--- a/buffalo/cmd/root.go
+++ b/buffalo/cmd/root.go
@@ -34,8 +34,8 @@ func goInstall(pkg string) *exec.Cmd {
 	return generate.GoInstall(pkg)
 }
 
-func goGet(pkg string) *exec.Cmd {
-	return generate.GoGet(pkg)
+func goGet(pkg string, buildFlags ...string) *exec.Cmd {
+	return generate.GoGet(pkg, buildFlags...)
 }
 
 // func init() {

--- a/buffalo/cmd/soda_generators.go
+++ b/buffalo/cmd/soda_generators.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/markbates/gentronics"
 	"github.com/markbates/pop/soda/cmd/generate"
-	"github.com/pkg/errors"
 )
 
 func newSodaGenerator() *gentronics.Generator {
@@ -23,17 +22,7 @@ func newSodaGenerator() *gentronics.Generator {
 	g.Add(&gentronics.Func{
 		Should: should,
 		Runner: func(rootPath string, data gentronics.Data) error {
-			var driver string
-			if data["dbType"] == "sqlite3" {
-				driver = "sqlite_driver"
-			} else if data["dbType"] == "postgres" {
-				driver = "postgresql_driver"
-			} else if data["dbType"] == "mysql" {
-				driver = "mysql_driver"
-			} else {
-				return errors.Errorf("Invalid database type %s!", data["dbType"])
-			}
-			gentronics.NewCommand(goGet("github.com/markbates/pop/...", "-tags", "'"+driver+"'"))
+			gentronics.NewCommand(goGet("github.com/markbates/pop/...", "-tags", "'"+data["dbType"].(string)+"'"))
 			return nil
 		},
 	})


### PR DESCRIPTION
Related to https://github.com/markbates/pop/issues/27.

Will allow buffalo to use the only needed database driver dependencies.