### PR TITLE
Webpack v2.2.1 upgrade

### DIFF
--- a/buffalo/cmd/generate/webpack.go
+++ b/buffalo/cmd/generate/webpack.go
@@ -107,7 +107,7 @@ func NewWebpackGenerator(data gentronics.Data) *gentronics.Generator {
 	c := gentronics.NewCommand(exec.Command(command, "init", "-y"))
 	g.Add(c)
 
-	modules := []string{"webpack@^1.14.0", "sass-loader", "css-loader", "style-loader", "node-sass",
+	modules := []string{"webpack@^2.2.1", "sass-loader", "css-loader", "style-loader", "node-sass",
 		"babel-loader", "extract-text-webpack-plugin", "babel", "babel-core", "url-loader", "file-loader",
 		"jquery", "bootstrap", "path", "font-awesome", "npm-install-webpack-plugin", "jquery-ujs",
 		"copy-webpack-plugin", "expose-loader",
@@ -153,40 +153,48 @@ module.exports = {
     })
   ],
   module: {
-    loaders: [{
+    rules: [{
       test: /\.jsx?$/,
-      loader: "babel",
+      loader: "babel-loader",
       exclude: /node_modules/
     }, {
       test: /\.scss$/,
-      loader: ExtractTextPlugin.extract(
-        "style",
-        "css?sourceMap!sass?sourceMap"
-      )
+      use: ExtractTextPlugin.extract({
+        fallback: "style-loader",
+        use:
+        [{
+          loader: "css-loader",
+          options: { sourceMap: true }
+      	},
+        {
+          loader: "sass-loader",
+          options: { sourceMap: true }
+        }]
+      })
     }, {
       test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-      loader: "url?limit=10000&mimetype=application/font-woff"
+      use: "url-loader?limit=10000&mimetype=application/font-woff"
     }, {
       test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-      loader: "url?limit=10000&mimetype=application/font-woff"
+      use: "url-loader?limit=10000&mimetype=application/font-woff"
     }, {
       test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-      loader: "url?limit=10000&mimetype=application/octet-stream"
+      use: "url-loader?limit=10000&mimetype=application/octet-stream"
     }, {
       test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-      loader: "file"
+      use: "file-loader"
     }, {
       test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-      loader: "url?limit=10000&mimetype=image/svg+xml"
+      use: "url-loader?limit=10000&mimetype=image/svg+xml"
     }, {
       test: require.resolve('jquery'),
-      loader: 'expose?jQuery!expose?$'
+      use: 'expose-loader?jQuery!expose-loader?$'
     }]
   }
 };
 `
 
-const wApplicationJS = `require('expose?$!expose?jQuery!jquery');
+const wApplicationJS = `require('expose-loader?$!expose-loader?jQuery!jquery');
 require("bootstrap/dist/js/bootstrap.js");
 
 $(() => {


### PR DESCRIPTION
As it was issued in #262, buffalo has broken with the last release of extract-text-webpack-plugin. Now it is an stable version (reason to wait in #195) so I decided to upgrade and parse the webpack.config.js to work with webpack v2.2.1 and the last version of the mentioned plugin. I tested it with a generated application including this patch and seems to work fine. I hope to not have forgotten anything.

Solves #262 and #195 