### PR TITLE
Convert Buffalo to use Plush by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Buffalo would not be possible if not for all of the great projects it depends on
 
 ### Templating
 
-[github.com/gobuffalo/velvet](https://github.com/gobuffalo/velvet) - This templating package was chosen over the standard Go `html/template` package for a variety of reasons. The biggest of which is that it is significantly more flexible and easy to work with. It also has the added factor of being familiar to those who have worked with "Handlebars" or "Mustache" templates before.
+[github.com/gobuffalo/plush](https://github.com/gobuffalo/plush) - This templating package was chosen over the standard Go `html/template` package for a variety of reasons. The biggest of which is that it is significantly more flexible and easy to work with.
 
 ### Routing
 

--- a/buffalo/cmd/app_generators.go
+++ b/buffalo/cmd/app_generators.go
@@ -153,7 +153,7 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/render/resolvers"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 )
 
 var r *render.Engine
@@ -161,7 +161,7 @@ var r *render.Engine
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:     "application.html",
-		TemplateEngine: velvet.BuffaloRenderer,
+		TemplateEngine: plush.BuffaloRenderer,
 		FileResolverFunc: func() resolvers.FileResolver {
 			return &resolvers.RiceBox{
 				Box: rice.MustFindBox("../templates"),
@@ -233,13 +233,13 @@ const nIndexHTML = `<div class="row">
         </tr>
       </thead>
       <tbody>
-        \{{#each routes as |r|}}
+				<%= for (r) in routes { %>
         <tr>
-          <td>\{{r.Method}}</td>
-          <td>\{{r.Path}}</td>
-          <td><code>\{{r.HandlerName}}</code></td>
+          <td><%= r.Method %></td>
+          <td><%= r.Path %></td>
+          <td><code><%= r.HandlerName %></code></td>
         </tr>
-        \{{/each}}
+				<% } %>
       </tbody>
     </table>
   </div>
@@ -256,7 +256,7 @@ const nApplicationHTML = `<html>
 <body>
 
   <div class="container">
-    \{{ yield }}
+		<%= yield %>
   </div>
 
   <script src="/assets/application.js" type="text/javascript" charset="utf-8"></script>

--- a/buffalo/cmd/build.go
+++ b/buffalo/cmd/build.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/buffalo/buffalo/cmd/generate"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/spf13/cobra"
 )
 
@@ -286,7 +286,7 @@ func (b *builder) buildMain() error {
 		return err
 	}
 
-	ctx := velvet.NewContext()
+	ctx := plush.NewContext()
 	ctx.Set("root", rootPath)
 	ctx.Set("hasDB", hasDB)
 	if hasDB {
@@ -298,7 +298,7 @@ func (b *builder) buildMain() error {
 	}
 	ctx.Set("aPack", packagePath(rootPath)+"/a")
 	ctx.Set("name", filepath.Base(rootPath))
-	s, err := velvet.Render(buildMainTmpl, ctx)
+	s, err := plush.Render(buildMainTmpl, ctx)
 	if err != nil {
 		return err
 	}
@@ -473,15 +473,15 @@ import (
 
 	"github.com/markbates/grift/grift"
 	rice "github.com/GeertJohan/go.rice"
-	_ "{{aPack}}"
-	{{#if modelsPack}}
+	_ "<%= aPack %>"
+	<%= if (modelsPack) { %>
 	"io/ioutil"
 	"path/filepath"
-	"{{modelsPack}}"
-	{{/if}}
-	{{#if griftsPack}}
-	_ "{{griftsPack}}"
-	{{/if}}
+	"<%= modelsPack %>"
+	<% } %>
+	<%= if (griftsPack) { %>
+	_ "<%= griftsPack %>"
+	<% } %>
 )
 
 var version = "unknown"
@@ -495,10 +495,10 @@ func main() {
 	}
 	c := args[1]
 	switch c {
-	{{#if modelsPack}}
+	<%= if (modelsPack) { %>
 	case "migrate":
 		migrate()
-	{{/if}}
+	<% } %>
 	case "start", "run", "serve":
 		printVersion()
 		originalMain()
@@ -515,10 +515,10 @@ func main() {
 }
 
 func printVersion() {
-	fmt.Printf("{{name}} version %s (%s)\n\n", version, buildTime)
+	fmt.Printf("<%= name %> version %s (%s)\n\n", version, buildTime)
 }
 
-{{#if modelsPack}}
+<%= if (modelsPack) { %>
 func migrate() {
 	var err error
 	migrationBox, err = rice.FindBox("./migrations")
@@ -537,7 +537,7 @@ func migrate() {
 }
 
 func unpackMigrations() (string, error) {
-	dir, err := ioutil.TempDir("", "{{name}}-migrations")
+	dir, err := ioutil.TempDir("", "<%= name %>-migrations")
 	if err != nil {
 		log.Fatalf("Unable to create temp directory: %s", err)
 	}
@@ -555,7 +555,7 @@ func unpackMigrations() (string, error) {
 
 	return dir, nil
 }
-{{/if}}
+<% } %>
 `
 
 var aGo = `package a
@@ -571,7 +571,6 @@ func init() {
 
 func dropDatabaseYml() {
 	if DB_CONFIG != "" {
-
 		_, err := os.Stat("database.yml")
 		if err == nil {
 			// yaml already exists, don't do anything

--- a/buffalo/cmd/dev.go
+++ b/buffalo/cmd/dev.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 
 	"github.com/gobuffalo/buffalo/buffalo/cmd/generate"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/markbates/refresh/refresh"
 	"github.com/spf13/cobra"
 )
@@ -76,7 +76,7 @@ func startDevServer(ctx context.Context) error {
 			return err
 		}
 		defer f.Close()
-		t, err := velvet.Render(nRefresh, velvet.NewContextWith(map[string]interface{}{
+		t, err := plush.Render(nRefresh, plush.NewContextWith(map[string]interface{}{
 			"name": "buffalo",
 		}))
 		if err != nil {

--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/envy"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/markbates/inflect"
 	"github.com/spf13/cobra"
 )
@@ -105,7 +105,7 @@ func validateInGoPath(name string) error {
 		if err != nil {
 			return err
 		}
-		t, err := velvet.Render(notInGoWorkspace, velvet.NewContextWith(map[string]interface{}{
+		t, err := plush.Render(notInGoWorkspace, plush.NewContextWith(map[string]interface{}{
 			"name":     name,
 			"gopath":   gp,
 			"current":  rootPath,
@@ -184,13 +184,13 @@ func init() {
 
 const notInGoWorkspace = `Oops! It would appear that you are not in your Go Workspace.
 
-Your $GOPATH is set to "{{gopath}}".
+Your $GOPATH is set to "<%= gopath %>".
 
-You are currently in "{{current}}".
+You are currently in "<%= current %>".
 
-The standard location for putting Go projects is something along the lines of "$GOPATH/src/github.com/{{username}}/{{name}}" (adjust accordingly).
+The standard location for putting Go projects is something along the lines of "$GOPATH/src/github.com/<%= username %>/<%= name %>" (adjust accordingly).
 
-We recommend you go to "$GOPATH/src/github.com/{{username}}/" and try "buffalo new {{name}}" again.`
+We recommend you go to "$GOPATH/src/github.com/<%= username %>/" and try "buffalo new <%= name %>" again.`
 
 const noGoPath = `You do not have a $GOPATH set. In order to work with Go, you must set up your $GOPATH and your Go Workspace.
 

--- a/default_context_test.go
+++ b/default_context_test.go
@@ -89,7 +89,7 @@ func Test_DefaultContext_Render(t *testing.T) {
 	c.params = url.Values{"name": []string{"Mark"}}
 	c.Set("greet", "Hello")
 
-	err := c.Render(123, render.String("{{greet}} {{params.name}}!"))
+	err := c.Render(123, render.String(`<%= greet %> <%= params["name"] %>!`))
 	r.NoError(err)
 
 	r.Equal(123, res.Code)

--- a/errors.go
+++ b/errors.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/pkg/errors"
 )
 
@@ -71,8 +71,8 @@ func defaultErrorHandler(status int, err error, c Context) error {
 			"status": status,
 			"data":   c.Data(),
 		}
-		ctx := velvet.NewContextWith(data)
-		t, err := velvet.Render(devErrorTmpl, ctx)
+		ctx := plush.NewContextWith(data)
+		t, err := plush.Render(devErrorTmpl, ctx)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -87,7 +87,7 @@ func defaultErrorHandler(status int, err error, c Context) error {
 var devErrorTmpl = `
 <html>
 <head>
-	<title>{{status}} - ERROR!</title>
+	<title><%= status %> - ERROR!</title>
 	<style>
 		body {
 			font-family: helvetica;
@@ -121,13 +121,13 @@ var devErrorTmpl = `
 	</style>
 </head>
 <body>
-<h1>{{status}} - ERROR!</h1>
-<pre>{{error}}</pre>
+<h1><%= status %> - ERROR!</h1>
+<pre><%= error %></pre>
 <hr>
 <h3>Context</h3>
-<pre>{{#each data as |k v|}}
-{{inspect k}}: {{inspect v}}
-{{/each}}</pre>
+<pre><%= for (k, v) in data { %>
+<%= inspect(k) %>: <%= inspect(v) %>
+<% } %></pre>
 <hr>
 <h3>Routes</h3>
 <table id="buffalo-routes-table">
@@ -139,13 +139,13 @@ var devErrorTmpl = `
 		</tr>
 	</thead>
 	<tbody>
-		{{#each routes as |route|}}
+		<%= for (route) in routes { %>
 			<tr>
-				<td>{{route.Method}}</td>
-				<td>{{route.Path}}</td>
-				<td><code>{{route.HandlerName}}</code></td>
+				<td><%= route.Method %></td>
+				<td><%= route.Path %></td>
+				<td><code><%= route.HandlerName %></code></td>
 			</tr>
-		{{/each}}
+		<% } %>
 	</tbody>
 </table>
 </body>

--- a/examples/hello-world/actions/render.go
+++ b/examples/hello-world/actions/render.go
@@ -6,7 +6,7 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/render/resolvers"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 )
 
 var r *render.Engine
@@ -14,7 +14,7 @@ var r *render.Engine
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:     "application.html",
-		TemplateEngine: velvet.BuffaloRenderer,
+		TemplateEngine: plush.BuffaloRenderer,
 		FileResolverFunc: func() resolvers.FileResolver {
 			return &resolvers.RiceBox{
 				Box: rice.MustFindBox("../templates"),

--- a/examples/hello-world/templates/application.html
+++ b/examples/hello-world/templates/application.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="/assets/application.css" type="text/css" media="all" />
 </head>
 <body>
-  {{ yield }}
+  <%= yield %>
 
   <script src="/assets/application.js" type="text/javascript" charset="utf-8"></script>
 </body>

--- a/examples/html-crud/actions/render.go
+++ b/examples/html-crud/actions/render.go
@@ -6,7 +6,7 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/render/resolvers"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 )
 
 var r *render.Engine
@@ -14,7 +14,7 @@ var r *render.Engine
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:     "application.html",
-		TemplateEngine: velvet.BuffaloRenderer,
+		TemplateEngine: plush.BuffaloRenderer,
 		FileResolverFunc: func() resolvers.FileResolver {
 			return &resolvers.RiceBox{
 				Box: rice.MustFindBox("../templates"),

--- a/examples/html-crud/templates/_errors.html
+++ b/examples/html-crud/templates/_errors.html
@@ -1,9 +1,9 @@
-{{#if verrs }}
+<%= if (verrs) { %>
 <div class="errors">
   <ul>
-    {{#each verrs as |k v|}}
-      <li>{{ v }}</li>
-    {{/each}}
+    <%= for (k, v) in verrs { %>
+      <li><%= v %></li>
+    <% } %>
   </ul>
 </div>
-{{/if}}
+<% } %>

--- a/examples/html-crud/templates/application.html
+++ b/examples/html-crud/templates/application.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-  {{ yield }}
+  <%= yield %>
 
   <script src="/assets/jquery.js" type="text/javascript" charset="utf-8"></script>
   <script src="/assets/application.js" type="text/javascript" charset="utf-8"></script>

--- a/examples/html-crud/templates/users/_form.html
+++ b/examples/html-crud/templates/users/_form.html
@@ -1,14 +1,14 @@
 <div>
   <label for="FirstName">First Name:</label>
-  <input type="text" name="FirstName" id="FirstName" value="{{ user.FirstName }}" />
+  <input type="text" name="FirstName" id="FirstName" value="<%= user.FirstName %>" />
 </div>
 <div>
   <label for="LastName">Last Name:</label>
-  <input type="text" name="LastName" id="LastName" value="{{ user.LastName }}" />
+  <input type="text" name="LastName" id="LastName" value="<%= user.LastName %>" />
 </div>
 <div>
   <label for="Email">Email:</label>
-  <input type="email" name="Email" id="Email" value="{{ user.Email }}" />
+  <input type="email" name="Email" id="Email" value="<%= user.Email %>" />
 </div>
 <div>
   <input type="submit" value="Save" />

--- a/examples/html-crud/templates/users/edit.html
+++ b/examples/html-crud/templates/users/edit.html
@@ -1,7 +1,7 @@
 <h1>Edit User</h1>
 
-{{ partial "errors.html" }}
-<form action="/users/{{ user.ID }}" method="POST" accept-charset="utf-8">
+<%= partial("errors.html") %>
+<form action="/users/<%= user.ID %>" method="POST" accept-charset="utf-8">
   <input type="hidden" name="_method" id="_method" value="PUT" />
-  {{ partial "users/form.html" }}
+  <%= partial("users/form.html") %>
 </form>

--- a/examples/html-crud/templates/users/index.html
+++ b/examples/html-crud/templates/users/index.html
@@ -10,17 +10,17 @@
     <th></th>
   </thead>
   <tbody>
-    {{#each users as |user|}}
+    <%= for (user) in users { %>
     <tr>
-      <td>{{ user.FirstName }}</td>
-      <td>{{ user.LastName }}</td>
-      <td>{{ user.Email }}</td>
+      <td><%= user.FirstName %></td>
+      <td><%= user.LastName %></td>
+      <td><%= user.Email %></td>
       <td>
-        <a href="/users/{{ user.ID }}">View</a>
-        <a href="/users/{{ user.ID }}/edit">Edit</a>
-        <a href="/users/{{ user.ID }}" data-method="DELETE" data-confirm="Are you sure?">Destroy</a>
+        <a href="/users/<%= user.ID %>">View</a>
+        <a href="/users/<%= user.ID %>/edit">Edit</a>
+        <a href="/users/<%= user.ID %>" data-method="DELETE" data-confirm="Are you sure?">Destroy</a>
       </td>
     </tr>
-    {{/each}}
+    <% } %>
   </tbody>
 </table>

--- a/examples/html-crud/templates/users/new.html
+++ b/examples/html-crud/templates/users/new.html
@@ -1,6 +1,6 @@
 <h1>New User</h1>
 
-{{ partial "errors.html" }}
+<%= partial("errors.html") %>
 <form action="/users" method="POST" accept-charset="utf-8">
-  {{ partial "users/form.html" }}
+  <%= partial("users/form.html") %>
 </form>

--- a/examples/html-crud/templates/users/show.html
+++ b/examples/html-crud/templates/users/show.html
@@ -1,26 +1,26 @@
-<h1>{{ user.FullName }}</h1>
+<h1><%= user.FullName %></h1>
 
 <p>
-  ID: {{ user.ID }}
+  ID: <%= user.ID %>
 </p>
 <p>
-  First Name: {{ user.FirstName }}
+  First Name: <%= user.FirstName %>
 </p>
 <p>
-  Last Name: {{ user.LastName }}
+  Last Name: <%= user.LastName %>
 </p>
 <p>
-  Email: {{ user.Email }}
+  Email: <%= user.Email %>
 </p>
 <p>
-  Created At: {{ user.CreatedAt }}
+  Created At: <%= user.CreatedAt %>
 </p>
 <p>
-  Updated At: {{ user.UpdatedAt }}
+  Updated At: <%= user.UpdatedAt %>
 </p>
 
 <p>
-  <a href="/users/{{ user.ID }}/edit">Edit</a> |
-  <a href="/users/{{ user.ID }}" data-method="DELETE" data-confirm="Are you sure?">Destroy</a> |
+  <a href="/users/<%= user.ID %>/edit">Edit</a> |
+  <a href="/users/<%= user.ID %>" data-method="DELETE" data-confirm="Are you sure?">Destroy</a> |
   <a href="/users">Back to All Users</a>
 </p>

--- a/examples/html-resource/actions/render.go
+++ b/examples/html-resource/actions/render.go
@@ -6,7 +6,7 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/render/resolvers"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 )
 
 var r *render.Engine
@@ -14,7 +14,7 @@ var r *render.Engine
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:     "application.html",
-		TemplateEngine: velvet.BuffaloRenderer,
+		TemplateEngine: plush.BuffaloRenderer,
 		FileResolverFunc: func() resolvers.FileResolver {
 			return &resolvers.RiceBox{
 				Box: rice.MustFindBox("../templates"),

--- a/examples/html-resource/templates/_errors.html
+++ b/examples/html-resource/templates/_errors.html
@@ -1,9 +1,9 @@
-{{# if verrs }}
+<%= if (verrs) { %>
 <div class="errors">
   <ul>
-    {{#each verrs as |k v|}}
-      <li>{{ v }}</li>
-    {{/each}}
+    <%= for (k, v) in verrs { %>
+      <li><%= v %></li>
+    <% } %>
   </ul>
 </div>
-{{/if}}
+<% } %>

--- a/examples/html-resource/templates/application.html
+++ b/examples/html-resource/templates/application.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-  {{ yield }}
+  <%= yield %>
 
   <script src="/assets/jquery.js" type="text/javascript" charset="utf-8"></script>
   <script src="/assets/application.js" type="text/javascript" charset="utf-8"></script>

--- a/examples/html-resource/templates/users/_form.html
+++ b/examples/html-resource/templates/users/_form.html
@@ -1,14 +1,14 @@
 <div>
   <label for="FirstName">First Name:</label>
-  <input type="text" name="FirstName" id="FirstName" value="{{ user.FirstName }}" />
+  <input type="text" name="FirstName" id="FirstName" value="<%= user.FirstName %>" />
 </div>
 <div>
   <label for="LastName">Last Name:</label>
-  <input type="text" name="LastName" id="LastName" value="{{ user.LastName }}" />
+  <input type="text" name="LastName" id="LastName" value="<%= user.LastName %>" />
 </div>
 <div>
   <label for="Email">Email:</label>
-  <input type="email" name="Email" id="Email" value="{{ user.Email }}" />
+  <input type="email" name="Email" id="Email" value="<%= user.Email %>" />
 </div>
 <div>
   <input type="submit" value="Save" />

--- a/examples/html-resource/templates/users/edit.html
+++ b/examples/html-resource/templates/users/edit.html
@@ -1,7 +1,7 @@
 <h1>Edit User</h1>
 
-{{ partial "errors.html" }}
-<form action="/users/{{ user.ID }}" method="POST" accept-charset="utf-8">
+<%= partial("errors.html") %>
+<form action="/users/<%= user.ID %>" method="POST" accept-charset="utf-8">
   <input type="hidden" name="_method" id="_method" value="PUT" />
-  {{ partial "users/form.html" }}
+  <%= partial("users/form.html") %>
 </form>

--- a/examples/html-resource/templates/users/index.html
+++ b/examples/html-resource/templates/users/index.html
@@ -10,17 +10,17 @@
     <th></th>
   </thead>
   <tbody>
-    {{#each users as |user|}}
+    <%= for (user) in users { %>
     <tr>
-      <td>{{ user.FirstName }}</td>
-      <td>{{ user.LastName }}</td>
-      <td>{{ user.Email }}</td>
+      <td><%= user.FirstName %></td>
+      <td><%= user.LastName %></td>
+      <td><%= user.Email %></td>
       <td>
-        <a href="/users/{{ user.ID }}">View</a>
-        <a href="/users/{{ user.ID }}/edit">Edit</a>
-        <a href="/users/{{ user.ID }}" data-method="DELETE" data-confirm="Are you sure?">Destroy</a>
+        <a href="/users/<%= user.ID %>">View</a>
+        <a href="/users/<%= user.ID %>/edit">Edit</a>
+        <a href="/users/<%= user.ID %>" data-method="DELETE" data-confirm="Are you sure?">Destroy</a>
       </td>
     </tr>
-    {{/each}}
+    <% } %>
   </tbody>
 </table>

--- a/examples/html-resource/templates/users/new.html
+++ b/examples/html-resource/templates/users/new.html
@@ -1,6 +1,6 @@
 <h1>New User</h1>
 
-{{ partial "errors.html" }}
+<%= partial("errors.html") %>
 <form action="/users" method="POST" accept-charset="utf-8">
-  {{ partial "users/form.html" }}
+  <%= partial("users/form.html") %>
 </form>

--- a/examples/html-resource/templates/users/show.html
+++ b/examples/html-resource/templates/users/show.html
@@ -1,26 +1,26 @@
-<h1>{{ user.FullName }}</h1>
+<h1><%= user.FullName %></h1>
 
 <p>
-  ID: {{ user.ID }}
+  ID: <%= user.ID %>
 </p>
 <p>
-  First Name: {{ user.FirstName }}
+  First Name: <%= user.FirstName %>
 </p>
 <p>
-  Last Name: {{ user.LastName }}
+  Last Name: <%= user.LastName %>
 </p>
 <p>
-  Email: {{ user.Email }}
+  Email: <%= user.Email %>
 </p>
 <p>
-  Created At: {{ user.CreatedAt }}
+  Created At: <%= user.CreatedAt %>
 </p>
 <p>
-  Updated At: {{ user.UpdatedAt }}
+  Updated At: <%= user.UpdatedAt %>
 </p>
 
 <p>
-  <a href="/users/{{ user.ID }}/edit">Edit</a> |
-  <a href="/users/{{ user.ID }}" data-method="DELETE" data-confirm="Are you sure?">Destroy</a> |
+  <a href="/users/<%= user.ID %>/edit">Edit</a> |
+  <a href="/users/<%= user.ID %>" data-method="DELETE" data-confirm="Are you sure?">Destroy</a> |
   <a href="/users">Back to All Users</a>
 </p>

--- a/examples/websockets/actions/render.go
+++ b/examples/websockets/actions/render.go
@@ -6,7 +6,7 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/buffalo/render/resolvers"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 )
 
 var r *render.Engine
@@ -14,7 +14,7 @@ var r *render.Engine
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:     "application.html",
-		TemplateEngine: velvet.BuffaloRenderer,
+		TemplateEngine: plush.BuffaloRenderer,
 		FileResolverFunc: func() resolvers.FileResolver {
 			return &resolvers.RiceBox{
 				Box: rice.MustFindBox("../templates"),

--- a/examples/websockets/templates/application.html
+++ b/examples/websockets/templates/application.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="/assets/application.css" type="text/css" media="all" />
 </head>
 <body>
-  {{ yield }}
+  <%= yield %>
 
   <script src="/assets/application.js" type="text/javascript" charset="utf-8"></script>
 </body>

--- a/flash_test.go
+++ b/flash_test.go
@@ -59,10 +59,12 @@ func Test_FlashRenderEmpty(t *testing.T) {
 	r.NotContains(res.Body.String(), "Flash:")
 }
 
-const errorsTPL = `{{#each flash.errors as |k value|}}
+const errorsTPL = `
+<%= for (k, v) in flash["errors"] { %>
 	Flash:
-    {{k}}:{{value}}
-{{/each}}`
+		<%= k %>:<%= v %>
+<% } %>
+`
 
 func Test_FlashRenderEntireFlash(t *testing.T) {
 	r := require.New(t)
@@ -79,10 +81,11 @@ func Test_FlashRenderEntireFlash(t *testing.T) {
 	r.Contains(res.Body.String(), "something to say!")
 }
 
-const keyTPL = `{{#each flash as |k value|}}
+const keyTPL = `<%= for (k, v) in flash { %>
 	Flash:
-    {{k}}:{{value}}
-{{/each}}`
+		<%= k %>:<%= v %>
+<% } %>
+`
 
 func Test_FlashRenderCustomKey(t *testing.T) {
 	r := require.New(t)

--- a/not_found.go
+++ b/not_found.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/pkg/errors"
 )
 
@@ -31,8 +31,8 @@ func NotFoundHandler(status int, err error, c Context) error {
 		res.WriteHeader(404)
 		return json.NewEncoder(res).Encode(data)
 	}
-	ctx := velvet.NewContextWith(data)
-	t, err := velvet.Render(htmlNotFound, ctx)
+	ctx := plush.NewContextWith(data)
+	t, err := plush.Render(htmlNotFound, ctx)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -66,7 +66,7 @@ var htmlNotFound = `
 </head>
 <body>
 <h1>404 Page Not Found!</h1>
-<h3>Could not find path <code>[{{method}}] {{path}}</code></h3>
+<h3>Could not find path <code>[<%= method %>] <%= path %></code></h3>
 <hr>
 <table id="buffalo-routes-table">
 	<thead>
@@ -77,20 +77,20 @@ var htmlNotFound = `
 		</tr>
 	</thead>
 	<tbody>
-		{{#each routes as |route|}}
+		<%= for (route) in routes { %>
 			<tr>
-				<td>{{route.Method}}</td>
-				<td>{{route.Path}}</td>
-				<td><code>{{route.HandlerName}}</code></td>
+				<td><%= route.Method %></td>
+				<td><%= route.Path %></td>
+				<td><code><%= route.HandlerName %></code></td>
 			</tr>
-		{{/each}}
+		<% } %>
 	</tbody>
 </table>
-{{#if error}}
+<%= if (error) { %>
 <hr>
 <h2>Error</h2>
-<pre>{{error}}</pre>
-{{/if}}
+<pre><%= error %></pre>
+<% } %>
 </body>
 </html>
 `

--- a/render/html_test.go
+++ b/render/html_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +19,7 @@ func Test_HTML(t *testing.T) {
 	r.NoError(err)
 	defer os.Remove(tmpFile.Name())
 
-	_, err = tmpFile.Write([]byte("{{name}}"))
+	_, err = tmpFile.Write([]byte("<%= name %>"))
 	r.NoError(err)
 
 	type ji func(...string) render.Renderer
@@ -27,7 +27,7 @@ func Test_HTML(t *testing.T) {
 		r := require.New(st)
 
 		j := render.New(render.Options{
-			TemplateEngine: velvet.BuffaloRenderer,
+			TemplateEngine: plush.BuffaloRenderer,
 		}).HTML
 
 		re := j(tmpFile.Name())
@@ -45,12 +45,12 @@ func Test_HTML(t *testing.T) {
 		r.NoError(err)
 		defer os.Remove(layout.Name())
 
-		_, err = layout.Write([]byte("<body>{{yield}}</body>"))
+		_, err = layout.Write([]byte("<body><%= yield %></body>"))
 		r.NoError(err)
 
 		re := render.New(render.Options{
 			HTMLLayout:     layout.Name(),
-			TemplateEngine: velvet.BuffaloRenderer,
+			TemplateEngine: plush.BuffaloRenderer,
 		})
 
 		st.Run("using just the HTMLLayout", func(sst *testing.T) {
@@ -70,7 +70,7 @@ func Test_HTML(t *testing.T) {
 			r.NoError(err)
 			defer os.Remove(nlayout.Name())
 
-			_, err = nlayout.Write([]byte("<html>{{yield}}</html>"))
+			_, err = nlayout.Write([]byte("<html><%= yield %></html>"))
 			r.NoError(err)
 			h := re.HTML(tmpFile.Name(), nlayout.Name())
 

--- a/render/markdown_test.go
+++ b/render/markdown_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +24,7 @@ func Test_Markdown(t *testing.T) {
 	tmpFile, err := os.Create(filepath.Join(tmpDir, "t.md"))
 	r.NoError(err)
 
-	_, err = tmpFile.Write([]byte("{{name}}"))
+	_, err = tmpFile.Write([]byte("<%= name %>"))
 	r.NoError(err)
 
 	type ji func(...string) render.Renderer
@@ -33,7 +33,7 @@ func Test_Markdown(t *testing.T) {
 
 		table := []ji{
 			render.New(render.Options{
-				TemplateEngine: velvet.BuffaloRenderer,
+				TemplateEngine: plush.BuffaloRenderer,
 			}).HTML,
 		}
 
@@ -54,12 +54,12 @@ func Test_Markdown(t *testing.T) {
 		r.NoError(err)
 		defer os.Remove(layout.Name())
 
-		_, err = layout.Write([]byte("<body>{{yield}}</body>"))
+		_, err = layout.Write([]byte("<body><%= yield %></body>"))
 		r.NoError(err)
 
 		re := render.New(render.Options{
 			HTMLLayout:     layout.Name(),
-			TemplateEngine: velvet.BuffaloRenderer,
+			TemplateEngine: plush.BuffaloRenderer,
 		}).HTML(tmpFile.Name())
 
 		r.Equal("text/html", re.ContentType())

--- a/render/options.go
+++ b/render/options.go
@@ -19,9 +19,6 @@ type Options struct {
 
 	// TemplateEngine to be used for rendering HTML templates
 	TemplateEngine TemplateEngine
-
-	// CacheTemplates option will be removed in 0.8.0.
-	CacheTemplates bool
 }
 
 // Resolver calls the FileResolverFunc and returns the resolver. The resolver

--- a/render/render.go
+++ b/render/render.go
@@ -1,11 +1,8 @@
 package render
 
 import (
-	"fmt"
-	"sync"
-
 	"github.com/gobuffalo/buffalo/render/resolvers"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 )
 
 // Engine used to power all defined renderers.
@@ -28,14 +25,7 @@ func New(opts Options) *Engine {
 		}
 	}
 	if opts.TemplateEngine == nil {
-		opts.TemplateEngine = velvet.BuffaloRenderer
-	}
-
-	if opts.CacheTemplates {
-		once := &sync.Once{}
-		once.Do(func() {
-			fmt.Println("[DEPRACTED] The 'CacheTemplates' option is deprecated in 0.8.0. To remove this warning please remove the option in your configuration.")
-		})
+		opts.TemplateEngine = plush.BuffaloRenderer
 	}
 
 	e := &Engine{

--- a/render/string_test.go
+++ b/render/string_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,10 +13,10 @@ func Test_String(t *testing.T) {
 	r := require.New(t)
 
 	j := render.New(render.Options{
-		TemplateEngine: velvet.BuffaloRenderer,
+		TemplateEngine: plush.BuffaloRenderer,
 	}).String
 
-	re := j("{{name}}")
+	re := j("<%= name %>")
 	r.Equal("text/plain", re.ContentType())
 	bb := &bytes.Buffer{}
 	err := re.Render(bb, map[string]interface{}{"name": "Mark"})

--- a/render/template_test.go
+++ b/render/template_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/velvet"
+	"github.com/gobuffalo/plush"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,14 +20,14 @@ func Test_Template(t *testing.T) {
 	r.NoError(err)
 	defer os.Remove(tmpFile.Name())
 
-	_, err = tmpFile.Write([]byte("{{name}}"))
+	_, err = tmpFile.Write([]byte("<%= name %>"))
 	r.NoError(err)
 
 	type ji func(string, ...string) render.Renderer
 
 	table := []ji{
 		render.New(render.Options{
-			TemplateEngine: velvet.BuffaloRenderer,
+			TemplateEngine: plush.BuffaloRenderer,
 		}).Template,
 	}
 
@@ -51,13 +51,13 @@ func Test_Template_Partial(t *testing.T) {
 	partFile, err := os.Create(filepath.Join(tPath, "_foo.html"))
 	r.NoError(err)
 
-	_, err = partFile.Write([]byte("Foo -> {{name}}"))
+	_, err = partFile.Write([]byte("Foo -> <%= name %>"))
 	r.NoError(err)
 
 	tmpFile, err := os.Create(filepath.Join(tPath, "index.html"))
 	r.NoError(err)
 
-	_, err = tmpFile.Write([]byte(`{{partial "foo.html"}}`))
+	_, err = tmpFile.Write([]byte(`<%= partial("foo.html") %>`))
 	r.NoError(err)
 
 	type ji func(string, ...string) render.Renderer
@@ -65,7 +65,7 @@ func Test_Template_Partial(t *testing.T) {
 	table := []ji{
 		render.New(render.Options{
 			TemplatesPath:  tPath,
-			TemplateEngine: velvet.BuffaloRenderer,
+			TemplateEngine: plush.BuffaloRenderer,
 		}).Template,
 	}
 

--- a/router_test.go
+++ b/router_test.go
@@ -213,7 +213,7 @@ func (u *userResource) List(c Context) error {
 }
 
 func (u *userResource) Show(c Context) error {
-	return c.Render(200, render.String("show {{params.user_id}}"))
+	return c.Render(200, render.String(`show <%=params["user_id"] %>`))
 }
 
 func (u *userResource) New(c Context) error {
@@ -225,13 +225,13 @@ func (u *userResource) Create(c Context) error {
 }
 
 func (u *userResource) Edit(c Context) error {
-	return c.Render(200, render.String("edit {{params.user_id}}"))
+	return c.Render(200, render.String(`edit <%=params["user_id"] %>`))
 }
 
 func (u *userResource) Update(c Context) error {
-	return c.Render(200, render.String("update {{params.user_id}}"))
+	return c.Render(200, render.String(`update <%=params["user_id"] %>`))
 }
 
 func (u *userResource) Destroy(c Context) error {
-	return c.Render(200, render.String("destroy {{params.user_id}}"))
+	return c.Render(200, render.String(`destroy <%=params["user_id"] %>`))
 }


### PR DESCRIPTION
This removes the use of Velvet when generating new Buffalo applications.

This PR does not address using Plush for internal code generation done through gentronics which currently uses Velvet. That will be addressed in a separate PR.