### PR TITLE
Switched to using github.com/gobuffalo/makr for generators

### DIFF
--- a/buffalo/cmd/console.go
+++ b/buffalo/cmd/console.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 	"github.com/markbates/inflect"
 	"github.com/spf13/cobra"
 )
@@ -31,9 +31,9 @@ var consoleCmd = &cobra.Command{
 		}
 
 		fname := inflect.Parameterize(packagePath) + "_loader.go"
-		g := gentronics.New()
-		g.Add(gentronics.NewFile(fname, cMain))
-		err = g.Run(os.TempDir(), gentronics.Data{
+		g := makr.New()
+		g.Add(makr.NewFile(fname, cMain))
+		err = g.Run(os.TempDir(), makr.Data{
 			"packages": packages,
 		})
 		os.Chdir(rootPath)
@@ -57,7 +57,7 @@ func init() {
 var cMain = `
 package main
 
-{{#each packages}}
+{{range .packages}}
 import _ "{{.}}"
-{{/each}}
+{{end}}
 `

--- a/buffalo/cmd/generate/action.go
+++ b/buffalo/cmd/generate/action.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/gobuffalo/buffalo/generators/action"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 	"github.com/markbates/inflect"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +26,7 @@ var ActionCmd = &cobra.Command{
 
 		name := args[0]
 
-		data := gentronics.Data{
+		data := makr.Data{
 			"filename":  inflect.Underscore(name),
 			"namespace": inflect.Camelize(name),
 		}

--- a/buffalo/cmd/generate/goth.go
+++ b/buffalo/cmd/generate/goth.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/gobuffalo/buffalo/generators/goth"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,7 @@ var GothCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return g.Run(".", gentronics.Data{
+		return g.Run(".", makr.Data{
 			"providers": args,
 		})
 	},

--- a/buffalo/cmd/generate/resource.go
+++ b/buffalo/cmd/generate/resource.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/gobuffalo/buffalo/generators/resource"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 	"github.com/markbates/inflect"
 	"github.com/spf13/cobra"
 )
@@ -19,7 +19,7 @@ var ResourceCmd = &cobra.Command{
 			return errors.New("you must specify a resource name")
 		}
 		name := args[0]
-		data := gentronics.Data{
+		data := makr.Data{
 			"name":         name,
 			"singular":     inflect.Singularize(name),
 			"plural":       inflect.Pluralize(name),

--- a/buffalo/cmd/generate/webpack.go
+++ b/buffalo/cmd/generate/webpack.go
@@ -2,7 +2,7 @@ package generate
 
 import (
 	"github.com/gobuffalo/buffalo/generators/assets/webpack"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ var WebpackCmd = &cobra.Command{
 	Use:   "webpack [flags]",
 	Short: "Generates a webpack asset pipeline.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		data := gentronics.Data{
+		data := makr.Data{
 			"withWebpack": true,
 			"withYarn":    withYarn,
 		}

--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -162,10 +162,12 @@ func genNewFiles() error {
 		"modelsPath":  packagePath + "/models",
 		"withPop":     !app.SkipPop,
 		"withWebpack": !app.SkipWebpack,
-		"withYarn":    app.WithYarn,
 		"dbType":      app.DBType,
 		"version":     Version,
 		"ciProvider":  app.CIProvider,
+	}
+	if app.WithYarn {
+		data["withYarn"] = true
 	}
 
 	g, err := app.Generator(data)

--- a/generators/action/templates.go
+++ b/generators/action/templates.go
@@ -4,12 +4,12 @@ const (
 	rActionFileT = `package actions
 import "github.com/gobuffalo/buffalo"`
 
-	rViewT = `<h1>{{namespace}}#{{action}}</h1>`
+	rViewT = `<h1>{{.namespace}}#{{.action}}</h1>`
 
 	rActionFuncT = `
-// {{namespace}}{{action}} default implementation.
-func {{namespace}}{{action}}(c buffalo.Context) error {
-	return c.Render(200, r.HTML("{{namespace_under}}/{{action_under}}.html"))
+// {{.namespace}}{{.action}} default implementation.
+func {{.namespace}}{{.action}}(c buffalo.Context) error {
+	return c.Render(200, r.HTML("{{.namespace_under}}/{{.action_under}}.html"))
 }
 `
 )

--- a/generators/assets/standard/standard.go
+++ b/generators/assets/standard/standard.go
@@ -5,23 +5,23 @@ import (
 
 	"github.com/gobuffalo/buffalo/generators"
 	"github.com/gobuffalo/buffalo/generators/assets"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 )
 
-var logo = &gentronics.RemoteFile{
-	File:       gentronics.NewFile("public/assets/images/logo.svg", ""),
+var logo = &makr.RemoteFile{
+	File:       makr.NewFile("public/assets/images/logo.svg", ""),
 	RemotePath: assets.LogoURL,
 }
 
 // New standard assets generator for those wishing to not use webpack
-func New(data gentronics.Data) (*gentronics.Generator, error) {
+func New(data makr.Data) (*makr.Generator, error) {
 	files, err := generators.Find(filepath.Join("assets", "standard"))
 	if err != nil {
 		return nil, err
 	}
-	g := gentronics.New()
+	g := makr.New()
 	for _, f := range files {
-		g.Add(gentronics.NewFile(f.WritePath, f.Body))
+		g.Add(makr.NewFile(f.WritePath, f.Body))
 	}
 	g.Add(logo)
 	return g, nil

--- a/generators/assets/webpack/webpack.go
+++ b/generators/assets/webpack/webpack.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/gobuffalo/buffalo/generators"
 	"github.com/gobuffalo/buffalo/generators/assets"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 )
 
-var logo = &gentronics.RemoteFile{
-	File:       gentronics.NewFile("assets/images/logo.svg", ""),
+var logo = &makr.RemoteFile{
+	File:       makr.NewFile("assets/images/logo.svg", ""),
 	RemotePath: assets.LogoURL,
 }
 
@@ -20,8 +20,8 @@ var logo = &gentronics.RemoteFile{
 var BinPath = filepath.Join("node_modules", ".bin", "webpack")
 
 // New webpack generator
-func New(data gentronics.Data) (*gentronics.Generator, error) {
-	g := gentronics.New()
+func New(data makr.Data) (*makr.Generator, error) {
+	g := makr.New()
 
 	// if there's no npm, return!
 	_, err := exec.LookPath("npm")
@@ -55,10 +55,10 @@ func New(data gentronics.Data) (*gentronics.Generator, error) {
 	}
 
 	for _, f := range files {
-		g.Add(gentronics.NewFile(f.WritePath, f.Body))
+		g.Add(makr.NewFile(f.WritePath, f.Body))
 	}
 
-	c := gentronics.NewCommand(exec.Command(command, "init", "-y"))
+	c := makr.NewCommand(exec.Command(command, "init", "-y"))
 	g.Add(c)
 
 	modules := []string{"webpack@^2.2.1", "sass-loader", "css-loader", "style-loader", "node-sass",
@@ -68,18 +68,18 @@ func New(data gentronics.Data) (*gentronics.Generator, error) {
 	}
 
 	args = append(args, modules...)
-	g.Add(gentronics.NewCommand(exec.Command(command, args...)))
+	g.Add(makr.NewCommand(exec.Command(command, args...)))
 	return g, nil
 }
 
-func generateYarn(data gentronics.Data) error {
+func generateYarn(data makr.Data) error {
 	// if there's no yarn, install it!
 	_, err := exec.LookPath("yarn")
-	// A new gentronics is necessary to have yarn available in path
+	// A new makr is necessary to have yarn available in path
 	if err != nil {
-		yg := gentronics.New()
+		yg := makr.New()
 		yargs := []string{"install", "-g", "yarn"}
-		yg.Add(gentronics.NewCommand(exec.Command("npm", yargs...)))
+		yg.Add(makr.NewCommand(exec.Command("npm", yargs...)))
 		err = yg.Run(".", data)
 		if err != nil {
 			return err

--- a/generators/goth/goth.go
+++ b/generators/goth/goth.go
@@ -4,22 +4,22 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/buffalo/generators"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 )
 
 // New actions/auth.go file configured to the specified providers.
-func New() (*gentronics.Generator, error) {
-	g := gentronics.New()
+func New() (*makr.Generator, error) {
+	g := makr.New()
 	files, err := generators.Find("goth")
 	if err != nil {
 		return nil, err
 	}
 	for _, f := range files {
-		g.Add(gentronics.NewFile(f.WritePath, f.Body))
+		g.Add(makr.NewFile(f.WritePath, f.Body))
 	}
-	g.Add(&gentronics.Func{
-		Should: func(data gentronics.Data) bool { return true },
-		Runner: func(root string, data gentronics.Data) error {
+	g.Add(&makr.Func{
+		Should: func(data makr.Data) bool { return true },
+		Runner: func(root string, data makr.Data) error {
 			err := generators.AddInsideAppBlock("auth := app.Group(\"/auth\")",
 				"auth.GET(\"/{provider}\", buffalo.WrapHandlerFunc(gothic.BeginAuthHandler))",
 				"auth.GET(\"/{provider}/callback\", AuthCallback)")
@@ -29,7 +29,7 @@ func New() (*gentronics.Generator, error) {
 			return generators.AddImport(filepath.Join("actions", "app.go"), "github.com/markbates/goth/gothic")
 		},
 	})
-	g.Add(gentronics.NewCommand(generators.GoGet("github.com/markbates/goth/...")))
-	g.Add(gentronics.NewCommand(generators.GoFmt()))
+	g.Add(makr.NewCommand(generators.GoGet("github.com/markbates/goth/...")))
+	g.Add(makr.NewCommand(generators.GoFmt()))
 	return g, nil
 }

--- a/generators/goth/templates/actions/auth.go.tmpl
+++ b/generators/goth/templates/actions/auth.go.tmpl
@@ -7,18 +7,18 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
-	{{#each providers}}
+	{{range .providers -}}
 	"github.com/markbates/goth/providers/{{ downcase . }}"
-	{{/each}}
+  {{end -}}
 )
 
 func init() {
 	gothic.Store = App().SessionStore
 
 	goth.UseProviders(
-		{{#each providers}}
+    {{range .providers -}}
 		{{downcase .}}.New(os.Getenv("{{upcase .}}_KEY"), os.Getenv("{{upcase .}}_SECRET"), fmt.Sprintf("%s%s", App().Host, "/auth/{{downcase .}}/callback")),
-		{{/each}}
+    {{end -}}
 	)
 }
 

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -84,13 +84,13 @@ env:
 - GO_ENV=test
 
 before_script:
-  - psql -c 'create database {{name}}_test;' -U postgres
-	- mysql -e 'CREATE DATABASE {{name}}_test;'
+  - psql -c 'create database {{.name}}_test;' -U postgres
+	- mysql -e 'CREATE DATABASE {{.name}}_test;'
   - mkdir -p $TRAVIS_BUILD_DIR/public/assets
 
 go:
   - 1.7.x
   - master
 
-go_import_path: {{ packagePath }}
+go_import_path: {{ .packagePath }}
 `

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gobuffalo/buffalo/generators/assets/standard"
 	"github.com/gobuffalo/buffalo/generators/assets/webpack"
 	"github.com/gobuffalo/buffalo/generators/refresh"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 )
 
 // App is the representation of a new Buffalo application
@@ -24,15 +24,15 @@ type App struct {
 }
 
 // Generator returns a generator to create a new application
-func (a *App) Generator(data gentronics.Data) (*gentronics.Generator, error) {
-	g := gentronics.New()
+func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
+	g := makr.New()
 	files, err := generators.Find("newapp")
 	if err != nil {
 		return nil, err
 	}
 
 	for _, f := range files {
-		g.Add(gentronics.NewFile(f.WritePath, f.Body))
+		g.Add(makr.NewFile(f.WritePath, f.Body))
 	}
 	rr, err := refresh.New()
 	if err != nil {
@@ -41,15 +41,15 @@ func (a *App) Generator(data gentronics.Data) (*gentronics.Generator, error) {
 	g.Add(rr)
 
 	if data["ciProvider"] == "travis" {
-		g.Add(gentronics.NewFile(".travis.yml", nTravis))
+		g.Add(makr.NewFile(".travis.yml", nTravis))
 	}
 
-	g.Add(gentronics.NewCommand(generators.GoGet("github.com/markbates/refresh/...")))
-	g.Add(gentronics.NewCommand(generators.GoInstall("github.com/markbates/refresh")))
-	g.Add(gentronics.NewCommand(generators.GoGet("github.com/markbates/grift/...")))
-	g.Add(gentronics.NewCommand(generators.GoInstall("github.com/markbates/grift")))
-	g.Add(gentronics.NewCommand(generators.GoGet("github.com/motemen/gore")))
-	g.Add(gentronics.NewCommand(generators.GoInstall("github.com/motemen/gore")))
+	g.Add(makr.NewCommand(generators.GoGet("github.com/markbates/refresh/...")))
+	g.Add(makr.NewCommand(generators.GoInstall("github.com/markbates/refresh")))
+	g.Add(makr.NewCommand(generators.GoGet("github.com/markbates/grift/...")))
+	g.Add(makr.NewCommand(generators.GoInstall("github.com/markbates/grift")))
+	g.Add(makr.NewCommand(generators.GoGet("github.com/motemen/gore")))
+	g.Add(makr.NewCommand(generators.GoInstall("github.com/motemen/gore")))
 	if a.SkipWebpack {
 		wg, err := standard.New(data)
 		if err != nil {
@@ -64,8 +64,8 @@ func (a *App) Generator(data gentronics.Data) (*gentronics.Generator, error) {
 		g.Add(wg)
 	}
 	g.Add(newSodaGenerator())
-	g.Add(gentronics.NewCommand(a.goGet()))
-	g.Add(gentronics.NewCommand(generators.GoFmt()))
+	g.Add(makr.NewCommand(a.goGet()))
+	g.Add(makr.NewCommand(generators.GoFmt()))
 
 	return g, nil
 }

--- a/generators/newapp/soda.go
+++ b/generators/newapp/soda.go
@@ -2,35 +2,35 @@ package newapp
 
 import (
 	"github.com/gobuffalo/buffalo/generators"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 	sg "github.com/markbates/pop/soda/cmd/generate"
 )
 
-func newSodaGenerator() *gentronics.Generator {
-	g := gentronics.New()
+func newSodaGenerator() *makr.Generator {
+	g := makr.New()
 
-	should := func(data gentronics.Data) bool {
+	should := func(data makr.Data) bool {
 		if _, ok := data["withPop"]; ok {
 			return ok
 		}
 		return false
 	}
 
-	f := gentronics.NewFile("models/models.go", nModels)
+	f := makr.NewFile("models/models.go", nModels)
 	f.Should = should
 	g.Add(f)
 
-	c := gentronics.NewCommand(generators.GoGet("github.com/markbates/pop/..."))
+	c := makr.NewCommand(generators.GoGet("github.com/markbates/pop/..."))
 	c.Should = should
 	g.Add(c)
 
-	c = gentronics.NewCommand(generators.GoInstall("github.com/markbates/pop/soda"))
+	c = makr.NewCommand(generators.GoInstall("github.com/markbates/pop/soda"))
 	c.Should = should
 	g.Add(c)
 
-	g.Add(&gentronics.Func{
+	g.Add(&makr.Func{
 		Should: should,
-		Runner: func(rootPath string, data gentronics.Data) error {
+		Runner: func(rootPath string, data makr.Data) error {
 			data["dialect"] = data["dbType"]
 			return sg.GenerateConfig("./database.yml", data)
 		},

--- a/generators/newapp/templates/README.md.tmpl
+++ b/generators/newapp/templates/README.md.tmpl
@@ -2,21 +2,21 @@
 
 Thank you for chosing Buffalo for your web development needs.
 
-{{#if withPop}}
+{{ if .withPop}}
 ## Database Setup
 
-It looks like you chose to set up your application using a {{dbType}} database! Fantastic!
+It looks like you chose to set up your application using a {{.dbType}} database! Fantastic!
 
 The first thing you need to do is open up the "database.yml" file and edit it to use the correct usernames, passwords, hosts, etc... that are appropriate for your environment.
 
-You will also need to make sure that **you** start/install the database of your choice. Buffalo **won't** install and start {{dbType}} for you.
+You will also need to make sure that **you** start/install the database of your choice. Buffalo **won't** install and start {{.dbType}} for you.
 
 ### Create Your Databases
 
-Ok, so you've edited the "database.yml" file and started {{dbType}}, now Buffalo can create the databases in that file for you:
+Ok, so you've edited the "database.yml" file and started {{.dbType}}, now Buffalo can create the databases in that file for you:
 
 	$ buffalo db create -a
-{{/if}}
+{{end}}
 
 ## Starting the Application
 

--- a/generators/newapp/templates/actions/app.go.tmpl
+++ b/generators/newapp/templates/actions/app.go.tmpl
@@ -2,10 +2,10 @@ package actions
 
 import (
 	"github.com/gobuffalo/buffalo"
-	{{#if withPop }}
+	{{ if .withPop }}
 	"github.com/gobuffalo/buffalo/middleware"
-	"{{modelsPath}}"
-	{{/if}}
+	"{{.modelsPath}}"
+  {{ end }}
 	"github.com/gobuffalo/envy"
 )
 
@@ -21,12 +21,12 @@ func App() *buffalo.App {
 	if app == nil {
 		app = buffalo.Automatic(buffalo.Options{
 			Env: ENV,
-			SessionName: "_{{name}}_session",
+			SessionName: "_{{.name}}_session",
 		})
 
-		{{#if withPop }}
+		{{ if .withPop }}
 		app.Use(middleware.PopTransaction(models.DB))
-		{{/if}}
+    {{ end }}
 
 		app.GET("/", HomeHandler)
 

--- a/generators/newapp/templates/actions/home_test.go.tmpl
+++ b/generators/newapp/templates/actions/home_test.go.tmpl
@@ -3,7 +3,7 @@ package actions_test
 import (
 	"testing"
 
-	"{{actionsPath}}"
+	"{{ .actionsPath }}"
 	"github.com/markbates/willie"
 	"github.com/stretchr/testify/require"
 )

--- a/generators/newapp/templates/dot-gitignore.tmpl
+++ b/generators/newapp/templates/dot-gitignore.tmpl
@@ -8,4 +8,4 @@ node_modules/
 .sass-cache/
 rice-box.go
 public/assets/
-{{ name }}
+{{ .name }}

--- a/generators/newapp/templates/grifts/routes.go.tmpl
+++ b/generators/newapp/templates/grifts/routes.go.tmpl
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	. "github.com/markbates/grift/grift"
-	"{{actionsPath}}"
+	"{{ .actionsPath }}"
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/generators/newapp/templates/main.go.tmpl
+++ b/generators/newapp/templates/main.go.tmpl
@@ -5,12 +5,12 @@ import (
 	"log"
 	"net/http"
 
-	"{{actionsPath}}"
+	"{{ .actionsPath }}"
 	"github.com/gobuffalo/envy"
 )
 
 func main() {
 	port := envy.Get("PORT", "3000")
-	log.Printf("Starting {{name}} on port %s\n", port)
+	log.Printf("Starting {{.name}} on port %s\n", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), actions.App()))
 }

--- a/generators/newapp/templates/templates/application.html.tmpl
+++ b/generators/newapp/templates/templates/application.html.tmpl
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Buffalo - {{ titleName }}</title>
+    <title>Buffalo - {{ .titleName }}</title>
     <link rel="stylesheet" href="/assets/application.css" type="text/css" media="all" />
   </head>
   <body>

--- a/generators/newapp/templates/templates/index.html.tmpl
+++ b/generators/newapp/templates/templates/index.html.tmpl
@@ -3,7 +3,7 @@
     <img src="/assets/images/logo.svg" alt="" />
   </div>
   <div class="col-md-10">
-    <h1>Welcome to Buffalo! [v{{version}}]</h1>
+    <h1>Welcome to Buffalo! [v{{.version}}]</h1>
     <h2>
       <a href="https://github.com/gobuffalo/buffalo"><i class="fa fa-github" aria-hidden="true"></i> https://github.com/gobuffalo/buffalo</a>
     </h2>

--- a/generators/refresh/refresh.go
+++ b/generators/refresh/refresh.go
@@ -2,12 +2,12 @@ package refresh
 
 import (
 	"github.com/gobuffalo/buffalo/generators"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 )
 
 // New generator for a .buffalo.dev.yml file
-func New() (*gentronics.Generator, error) {
-	g := gentronics.New()
+func New() (*makr.Generator, error) {
+	g := makr.New()
 
 	files, err := generators.Find("refresh")
 	if err != nil {
@@ -15,7 +15,7 @@ func New() (*gentronics.Generator, error) {
 	}
 
 	for _, f := range files {
-		g.Add(gentronics.NewFile(f.WritePath, f.Body))
+		g.Add(makr.NewFile(f.WritePath, f.Body))
 	}
 
 	return g, nil

--- a/generators/refresh/templates/dot-buffalo.dev.yml.tmpl
+++ b/generators/refresh/templates/dot-buffalo.dev.yml.tmpl
@@ -14,7 +14,7 @@ included_extensions:
 - .go
 build_path: tmp
 build_delay: 200ns
-binary_name: {{name}}-build
+binary_name: {{.name}}-build
 command_flags: []
 enable_colors: true
 log_name: buffalo

--- a/generators/resource/resource.go
+++ b/generators/resource/resource.go
@@ -5,28 +5,28 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/buffalo/generators"
-	"github.com/markbates/gentronics"
+	"github.com/gobuffalo/makr"
 )
 
 // New generates a new actions/resource file and a stub test.
-func New(data gentronics.Data) (*gentronics.Generator, error) {
-	g := gentronics.New()
+func New(data makr.Data) (*makr.Generator, error) {
+	g := makr.New()
 	files, err := generators.Find("resource")
 	if err != nil {
 		return nil, err
 	}
 	for _, f := range files {
-		g.Add(gentronics.NewFile(strings.Replace(f.WritePath, "resource-name", data["under"].(string), -1), f.Body))
+		g.Add(makr.NewFile(strings.Replace(f.WritePath, "resource-name", data["under"].(string), -1), f.Body))
 	}
-	g.Add(&gentronics.Func{
-		Should: func(data gentronics.Data) bool { return true },
-		Runner: func(root string, data gentronics.Data) error {
+	g.Add(&makr.Func{
+		Should: func(data makr.Data) bool { return true },
+		Runner: func(root string, data makr.Data) error {
 			return generators.AddInsideAppBlock(fmt.Sprintf("var %sResource buffalo.Resource", data["downFirstCap"]),
 				fmt.Sprintf("%sResource = %sResource{&buffalo.BaseResource{}}", data["downFirstCap"], data["camel"]),
 				fmt.Sprintf("app.Resource(\"/%s\", %sResource)", data["under"], data["downFirstCap"]),
 			)
 		},
 	})
-	g.Add(gentronics.NewCommand(generators.GoFmt()))
+	g.Add(makr.NewCommand(generators.GoFmt()))
 	return g, nil
 }

--- a/generators/resource/templates/actions/resource-name.go.tmpl
+++ b/generators/resource/templates/actions/resource-name.go.tmpl
@@ -2,14 +2,14 @@ package actions
 
 import "github.com/gobuffalo/buffalo"
 
-type {{camel}}Resource struct{
+type {{.camel}}Resource struct{
 	buffalo.Resource
 }
 
-{{#each actions}}
-// {{.}} default implementation.
-func (v {{camel}}Resource) {{.}}(c buffalo.Context) error {
-	return c.Render(200, r.String("{{camel}}#{{.}}"))
+{{ range $a := .actions }}
+// {{$a}} default implementation.
+func (v {{$.camel}}Resource) {{$a}}(c buffalo.Context) error {
+	return c.Render(200, r.String("{{$.camel}}#{{$a}}"))
 }
 
-{{/each}}
+{{end}}

--- a/generators/resource/templates/actions/resource-name_test.go.tmpl
+++ b/generators/resource/templates/actions/resource-name_test.go.tmpl
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-{{#each actions}}
-func Test_{{camel}}Resource_{{camelize .}}(t *testing.T) {
+{{ range $a := .actions }}
+func Test_{{$.camel}}Resource_{{ camelize $a }}(t *testing.T) {
 	r := require.New(t)
 	r.Fail("Not Implemented!")
 }
-{{/each}}
+{{ end }}


### PR DESCRIPTION
This is essentially a fork of github.com/markbates/gentronics, but uses standard go `text/template` for templating to keep the dependency count down.