### PR TITLE
Fix #181: generate default gitlab ci config

### DIFF
--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -190,7 +190,7 @@ func init() {
 	newCmd.Flags().BoolVar(&app.SkipWebpack, "skip-webpack", false, "skips adding Webpack to your app")
 	newCmd.Flags().BoolVar(&app.WithYarn, "with-yarn", false, "allows the use of yarn instead of npm as dependency manager")
 	newCmd.Flags().StringVar(&app.DBType, "db-type", "postgres", "specify the type of database you want to use [postgres, mysql, sqlite3]")
-	newCmd.Flags().StringVar(&app.CIProvider, "ci-provider", "none", "specify the type of ci file you would like buffalo to generate [none, travis]")
+	newCmd.Flags().StringVar(&app.CIProvider, "ci-provider", "none", "specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci]")
 }
 
 const notInGoWorkspace = `Oops! It would appear that you are not in your Go Workspace.


### PR DESCRIPTION
Still one question remaining:

> My problem is the way the database.yml is generated:
> 
> ```yaml
> test:
>   dialect: postgres
>   database: buffalo-test_test
>   user: postgres
>   password: postgres
>   host: 127.0.0.1
> ```
> 
> Since the PostgreSQL server is not on 127.0.0.1 in this case (it will be on a dynamic host created by Gitlab), the test will fail. So, we can either:
> - ask the user to change the host by hand
> - let Buffalo customize it by tweaking Pop
> - change Pop template to use `envOr` helper on test case (so we can provide env in the ci script)
> - tweak it at build time, with a bash command like `sed` or `awk`
> 
> In my opinion, the third option is the best and would not break legacy setups.