### PR TITLE
Adds a buffalo version command to the CLI

### DIFF
--- a/buffalo/cmd/version.go
+++ b/buffalo/cmd/version.go
@@ -1,4 +1,23 @@
 package cmd
 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 // Version is the current version of the buffalo binary
 const Version = "0.8.0.dev"
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of buffalo",
+	Long:  `All software has versions.  This is buffalo's.`,
+	Run: func(c *cobra.Command, args []string) {
+		fmt.Println("Buffalo version %s", Version)
+	},
+}


### PR DESCRIPTION
I had a little trouble getting dev environment set up and was wondering if anyone could provide some assistance.  Slash might be nice to have a "How to contribute" doc somewhere?

After forking the repo I `git cloned` it into my go github.com/spencercdixon workspace.  When I tried to build the CLI though I get this:

![screen shot 2017-03-26 at 10 16 21 am](https://cloud.githubusercontent.com/assets/7471018/24332057/dd0511f4-120d-11e7-99cc-0abd1d8ae36e.png)

This was the first Go project I ever worked on that wasn't a "hello world" type thing though so I'm probably just missing some very obvious steps haha.

Also, does go build cache the last successful build or something?  If I cd'ed into `buffalo/cmd` and ran `go build` it would always build the old version of buffalo even after I checkouted the latest 0.8 branch.  I feel like that's not normal....?
