### PR TITLE
Setup webpack to enable full ES6 transpile

### DIFF
--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -32,6 +32,9 @@ module.exports = {
     rules: [{
       test: /\.jsx?$/,
       loader: "babel-loader",
+      options: {
+        presets: ['env']
+      },
       exclude: /node_modules/
     }, {
       test: /\.scss$/,

--- a/generators/assets/webpack/webpack.go
+++ b/generators/assets/webpack/webpack.go
@@ -62,8 +62,8 @@ func New(data makr.Data) (*makr.Generator, error) {
 	g.Add(c)
 
 	modules := []string{"webpack@~2.3.0", "sass-loader", "css-loader", "style-loader", "node-sass",
-		"babel-loader", "extract-text-webpack-plugin", "babel", "babel-core", "url-loader", "file-loader",
-		"jquery", "bootstrap", "path", "font-awesome", "npm-install-webpack-plugin", "jquery-ujs",
+		"extract-text-webpack-plugin", "babel", "babel-core", "babel-preset-env", "babel-loader", "url-loader",
+		"file-loader", "jquery", "bootstrap", "path", "font-awesome", "npm-install-webpack-plugin", "jquery-ujs",
 		"copy-webpack-plugin", "expose-loader",
 	}
 


### PR DESCRIPTION
Add "babel-preset-env" dependency and setup babel "env" preset.

See: https://github.com/babel/babel-preset-env

You can see this works, by looking at the transpile of the empty lambda in application.js.

e.g. put this ES6 in `assets/application.js`

```javascript
$(() => {
    [1, 2, 3].map(n => n ** 2);
});
```
run `buffalo dev` and check `public/assets/js/application.js`

```javascript
$(function () {
    [1, 2, 3].map(function (n) {
        return Math.pow(n, 2);
    });
});
```
Prior to this change, you'd see the original ES6.

