### PR TITLE
Build webpack assets for production in `buffalo build`

### DIFF
--- a/buffalo/cmd/build.go
+++ b/buffalo/cmd/build.go
@@ -56,7 +56,7 @@ func (b *builder) buildWebpack() error {
 	_, err := os.Stat("webpack.config.js")
 	if err == nil {
 		// build webpack
-		return b.exec(webpack.BinPath)
+		return b.exec(webpack.BinPath, "-p")
 	}
 	return nil
 }


### PR DESCRIPTION
Pretty complex change :)

Build webpack assets for production in `buffalo build` by calling `webpack -p`

This performs JS minification by default and also sets NODE_ENV == "production", allowing production only build configs.

See: https://webpack.js.org/guides/production-build/