### PR TITLE
WIP: Add auto mode to resource generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,13 @@ RUN rm models/user_test.go
 RUN rm models/user.go
 RUN rm actions/users_test.go
 
+RUN buffalo g resource --type=auto users name:text email:text
+RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/resource_json-xml.json
+
+RUN rm models/user_test.go
+RUN rm models/user.go
+RUN rm actions/users_test.go
+
 WORKDIR $GOPATH/src
 RUN buffalo new --skip-pop simple_world
 WORKDIR ./simple_world

--- a/generators/resource/resource.go
+++ b/generators/resource/resource.go
@@ -25,7 +25,7 @@ func New(data makr.Data) (*makr.Generator, error) {
 
 	tmplName := "resource-use_model"
 
-	if mimeType == "json" || mimeType == "xml" {
+	if mimeType == "json" || mimeType == "xml" || mimeType == "auto" {
 		tmplName = "resource-json-xml"
 	} else if skipModel == true {
 		tmplName = "resource-name"

--- a/generators/resource/templates/actions/resource-json-xml.go.tmpl
+++ b/generators/resource/templates/actions/resource-json-xml.go.tmpl
@@ -39,7 +39,7 @@ func (v {{.camel}}Resource) List(c buffalo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.Render(200, r.{{.renderFunction}}({{.varPlural}}))
+	return c.Render(200, r.{{.renderFunction}}({{.varPlural}}{{.renderOptionalArgument}}))
 }
 
 // Show gets the data for one {{.model}}. This function is mapped to
@@ -54,7 +54,7 @@ func (v {{.camel}}Resource) Show(c buffalo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.Render(200, r.{{.renderFunction}}({{.varSingular}}))
+	return c.Render(200, r.{{.renderFunction}}({{.varSingular}}{{.renderOptionalArgument}}))
 }
 
 // New default implementation. Returns a 404
@@ -81,10 +81,10 @@ func (v {{.camel}}Resource) Create(c buffalo.Context) error {
 	}
 	if verrs.HasAny() {
 		// Render errors as {{.renderFunction}}
-		return c.Render(400, r.{{.renderFunction}}(verrs))
+		return c.Render(400, r.{{.renderFunction}}(verrs{{.renderOptionalArgument}}))
 	}
 	// Success!
-	return c.Render(201, r.{{.renderFunction}}({{.varSingular}}))
+	return c.Render(201, r.{{.renderFunction}}({{.varSingular}}{{.renderOptionalArgument}}))
 }
 
 // Edit default implementation. Returns a 404
@@ -114,10 +114,10 @@ func (v {{.camel}}Resource) Update(c buffalo.Context) error {
 	}
 	if verrs.HasAny() {
 		// Render errors as {{.renderFunction}}
-		return c.Render(400, r.{{.renderFunction}}(verrs))
+		return c.Render(400, r.{{.renderFunction}}(verrs{{.renderOptionalArgument}}))
 	}
 	// Success!
-	return c.Render(200, r.{{.renderFunction}}({{.varSingular}}))
+	return c.Render(200, r.{{.renderFunction}}({{.varSingular}}{{.renderOptionalArgument}}))
 }
 
 // Destroy deletes a {{.singular}} from the DB. This function is mapped
@@ -137,5 +137,5 @@ func (v {{.camel}}Resource) Destroy(c buffalo.Context) error {
 		return err
 	}
 	// Success!
-	return c.Render(200, r.{{.renderFunction}}({{.varSingular}}))
+	return c.Render(200, r.{{.renderFunction}}({{.varSingular}}{{.renderOptionalArgument}}))
 }

--- a/render/from_content_type.go
+++ b/render/from_content_type.go
@@ -1,0 +1,44 @@
+package render
+
+import (
+	"net/http"
+	"strings"
+)
+
+// FromContentType renders the value using the content type
+// detected in "Content-Type" header. If the header doesn't exist
+// it tries to fetch it from the "format" URL query argument.
+// However, if it fails to detect the content type, json is provided
+// as a fallback.
+func FromContentType(v interface{}, req *http.Request) Renderer {
+	if contentType, found := req.Header["Content-Type"]; found {
+		// Try to read content type from Content-Type HTTP header
+		if strings.EqualFold(contentType[0], "application/json") {
+			return jsonRenderer{value: v}
+		} else if strings.EqualFold(contentType[0], "application/xml") {
+			return xmlRenderer{value: v}
+		}
+	} else {
+		// Try to get content type as a query argument
+		format := req.URL.Query().Get("format")
+		if len(format) > 0 {
+			if strings.EqualFold(format, "json") {
+				return jsonRenderer{value: v}
+			} else if strings.EqualFold(format, "xml") {
+				return xmlRenderer{value: v}
+			}
+		}
+	}
+
+	// jsonRenderer as fallback
+	return jsonRenderer{value: v}
+}
+
+// FromContentType renders the value using the content type
+// detected in "Content-Type" header. If the header doesn't exist
+// it tries to fetch it from the "format" URL query argument.
+// However, if it fails to detect the content type, json is provided
+// as a fallback.
+func (e *Engine) FromContentType(v interface{}, req *http.Request) Renderer {
+	return FromContentType(v, req)
+}

--- a/render/from_content_type_test.go
+++ b/render/from_content_type_test.go
@@ -1,0 +1,76 @@
+package render_test
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gobuffalo/buffalo/render"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_FromContentType(t *testing.T) {
+	r := require.New(t)
+
+	type ji func(v interface{}, req *http.Request) render.Renderer
+
+	type user struct {
+		Name string
+	}
+
+	table := []ji{
+		render.FromContentType,
+		render.New(render.Options{}).FromContentType,
+	}
+
+	for _, j := range table {
+
+		// Test fallback on JSON
+		req, _ := http.NewRequest("GET", "http://localhost/", nil)
+		re := j(map[string]string{"hello": "world"}, req)
+		r.Equal("application/json", re.ContentType())
+		bb := &bytes.Buffer{}
+		err := re.Render(bb, nil)
+		r.NoError(err)
+		r.Equal(`{"hello":"world"}`, strings.TrimSpace(bb.String()))
+
+		// Test format query argument JSON
+		req, _ = http.NewRequest("GET", "http://localhost/?format=json", nil)
+		re = j(map[string]string{"hello": "world"}, req)
+		r.Equal("application/json", re.ContentType())
+		bb = &bytes.Buffer{}
+		err = re.Render(bb, nil)
+		r.NoError(err)
+		r.Equal(`{"hello":"world"}`, strings.TrimSpace(bb.String()))
+
+		// Test Content-Type header JSON
+		req, _ = http.NewRequest("GET", "http://localhost/", nil)
+		req.Header.Set("Content-Type", "application/json")
+		re = j(map[string]string{"hello": "world"}, req)
+		r.Equal("application/json", re.ContentType())
+		bb = &bytes.Buffer{}
+		err = re.Render(bb, nil)
+		r.NoError(err)
+		r.Equal(`{"hello":"world"}`, strings.TrimSpace(bb.String()))
+
+		// Test format query argument XML
+		req, _ = http.NewRequest("GET", "http://localhost/?format=xml", nil)
+		re = j(user{Name: "mark"}, req)
+		r.Equal("application/xml", re.ContentType())
+		bb = &bytes.Buffer{}
+		err = re.Render(bb, nil)
+		r.NoError(err)
+		r.Equal("<user>\n  <Name>mark</Name>\n</user>", strings.TrimSpace(bb.String()))
+
+		// Test Content-Type header XML
+		req, _ = http.NewRequest("GET", "http://localhost/", nil)
+		req.Header.Set("Content-Type", "application/xml")
+		re = j(user{Name: "mark"}, req)
+		r.Equal("application/xml", re.ContentType())
+		bb = &bytes.Buffer{}
+		err = re.Render(bb, nil)
+		r.NoError(err)
+		r.Equal("<user>\n  <Name>mark</Name>\n</user>", strings.TrimSpace(bb.String()))
+	}
+}


### PR DESCRIPTION
Using auto mode, the generated resource will be able to produce XML or
JSON contents, according to the "Content-Type" HTTP header, or the
"format" query argument.

If the content type can't be determined by either the HTTP header or the
"format" query argument, it fallbacks to JSON.