### PR TITLE
RequestLogger sets request_id in context

### DIFF
--- a/request_logger.go
+++ b/request_logger.go
@@ -25,9 +25,12 @@ func RequestLoggerFunc(h Handler) Handler {
 			c.Session().Set("requestor_id", irid)
 			c.Session().Save()
 		}
+		rid := irid.(string) + "-" + randx.String(10)
+		c.Set("request_id", rid)
+
 		now := time.Now()
 		c.LogFields(logrus.Fields{
-			"request_id": irid.(string) + "-" + randx.String(10),
+			"request_id": rid,
 			"method":     c.Request().Method,
 			"path":       c.Request().URL.String(),
 		})


### PR DESCRIPTION
Set the logger request_id in the context, which enables the rest of the request handling chain to use the ID. 

This is useful for:

- Including the request ID on errors sent to a service like Rollbar
- Passing the request ID to a subsystem to correlate logs