### PR TITLE
Set up github.com/golang/dep for new applications fixes #133

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM gobuffalo/buffalo:development
 
 RUN buffalo version
 
-RUN go get -u github.com/golang/lint/golint
-RUN go get -u github.com/markbates/filetest
+RUN go get -v -u github.com/golang/dep
+RUN go install -v github.com/golang/dep
+RUN go get -v -u github.com/golang/lint/golint
+RUN go get -v -u github.com/markbates/filetest
+RUN go get -v -u github.com/gobuffalo/makr
 
 ENV BP=$GOPATH/src/github.com/gobuffalo/buffalo
 
+RUN rm $(which buffalo)
 RUN rm -rf $BP
 RUN mkdir -p $BP
 WORKDIR $BP
@@ -14,11 +18,12 @@ ADD . .
 
 RUN go get -v -t ./...
 
+RUN go install -v ./buffalo
+
 RUN go test -race ./...
 
 RUN golint -set_exit_status ./...
 
-RUN go install ./buffalo
 
 WORKDIR $GOPATH/src/
 RUN buffalo new --db-type=sqlite3 hello_world --ci-provider=travis

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -11,6 +11,8 @@ RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key ad
 RUN apt-get update
 RUN apt-get install -y postgresql postgresql-contrib libpq-dev
 RUN apt-get install -y -q mysql-client
+RUN go get -v -u github.com/golang/dep
+RUN go install -v github.com/golang/dep
 
 ENV BP=$GOPATH/src/github.com/gobuffalo/buffalo
 

--- a/buffalo/cmd/setup.go
+++ b/buffalo/cmd/setup.go
@@ -53,7 +53,7 @@ Tests:
 }
 
 func updateGoDepsCheck() error {
-	if _, err := os.Stat("Gopkg.toml"); err == nil {
+	if _, err := exec.LookPath("Gopkg.toml"); err == nil {
 		// use github.com/golang/dep
 		args := []string{"ensure", "-v"}
 		if setupOptions.updateGoDeps {

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -59,6 +59,7 @@ func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
 		}
 	}
 
+	g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep")))
 	g.Add(makr.NewCommand(makr.GoGet("github.com/motemen/gore")))
 	g.Add(makr.NewCommand(makr.GoInstall("github.com/motemen/gore")))
 	if a.SkipWebpack {
@@ -84,12 +85,7 @@ func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
 }
 
 func (a App) goGet() *exec.Cmd {
-	appArgs := []string{"get", "-t"}
-	if a.Verbose {
-		appArgs = append(appArgs, "-v")
-	}
-	appArgs = append(appArgs, "./...")
-	return exec.Command("go", appArgs...)
+	return exec.Command("dep", "init")
 }
 
 const nTravis = `language: go

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -26,7 +26,12 @@ type App struct {
 // Generator returns a generator to create a new application
 func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
 	g := makr.New()
-	g.Add(makr.NewCommand(makr.GoGet("golang.org/x/tools/cmd/goimports")))
+	g.Add(makr.NewCommand(makr.GoGet("golang.org/x/tools/cmd/goimports", "-v", "-u")))
+	g.Add(makr.NewCommand(makr.GoInstall("golang.org/x/tools/cmd/goimports", "-v")))
+	g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep", "-v", "-u")))
+	g.Add(makr.NewCommand(makr.GoInstall("github.com/golang/dep", "-v")))
+	g.Add(makr.NewCommand(makr.GoGet("github.com/motemen/gore", "-v", "-u")))
+	g.Add(makr.NewCommand(makr.GoInstall("github.com/motemen/gore", "-v")))
 
 	files, err := generators.Find("newapp")
 	if err != nil {
@@ -59,9 +64,6 @@ func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
 		}
 	}
 
-	g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep")))
-	g.Add(makr.NewCommand(makr.GoGet("github.com/motemen/gore")))
-	g.Add(makr.NewCommand(makr.GoInstall("github.com/motemen/gore")))
 	if a.SkipWebpack {
 		wg, err := standard.New(data)
 		if err != nil {
@@ -85,7 +87,15 @@ func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
 }
 
 func (a App) goGet() *exec.Cmd {
-	return exec.Command("dep", "init")
+	if _, err := exec.LookPath("dep"); err == nil {
+		return exec.Command("dep", "init")
+	}
+	appArgs := []string{"get", "-t"}
+	if a.Verbose {
+		appArgs = append(appArgs, "-v")
+	}
+	appArgs = append(appArgs, "./...")
+	return exec.Command("go", appArgs...)
 }
 
 const nTravis = `language: go


### PR DESCRIPTION
Now that the github.com/golang/dep team has announced that the config files are "stable", we can now add dep support when generating new applications.