### PR TITLE
Prevents buffalo from executing commands outside the buffalo project

### DIFF
--- a/buffalo/cmd/db.go
+++ b/buffalo/cmd/db.go
@@ -16,9 +16,7 @@ func init() {
 
 	c := cmd.RootCmd
 	destroyCmd.AddCommand(destroy.ModelCmd)
-
 	decorate("destroy", destroyCmd)
-
 	c.AddCommand(destroyCmd)
 
 	c.Use = "db"

--- a/buffalo/cmd/root.go
+++ b/buffalo/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -14,8 +15,26 @@ var RootCmd = &cobra.Command{
 	SilenceErrors: true,
 	Use:           "buffalo",
 	Short:         "Helps you build your Buffalo applications that much easier!",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Buffalo version %s\n\n", Version)
+
+		anywhereCommands := []string{"new", "version"}
+		isFreeCommand := false
+		for _, freeCmd := range anywhereCommands {
+			if freeCmd == cmd.Name() {
+				isFreeCommand = true
+			}
+		}
+
+		if isFreeCommand {
+			return nil
+		}
+
+		if insideBuffaloProject() == false {
+			return errors.New("you need to be inside your buffalo project path to run this command")
+		}
+
+		return nil
 	},
 }
 
@@ -30,6 +49,14 @@ func Execute() {
 
 func init() {
 	decorate("root", RootCmd)
+}
+
+func insideBuffaloProject() bool {
+	if _, err := os.Stat(".buffalo.dev.yml"); err != nil {
+		return false
+	}
+
+	return true
 }
 
 // func init() {

--- a/buffalo/cmd/task.go
+++ b/buffalo/cmd/task.go
@@ -21,7 +21,8 @@ var taskCommand = &cobra.Command{
 
 		return grifts.Run("buffalo task", args)
 	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
 	},
 }
 

--- a/buffalo/cmd/version.go
+++ b/buffalo/cmd/version.go
@@ -22,6 +22,7 @@ var versionCmd = &cobra.Command{
 		fmt.Printf("Buffalo version is: %s\n", Version)
 	},
 	// needed to override the root level pre-run func
-	PersistentPreRun: func(c *cobra.Command, args []string) {
+	PersistentPreRunE: func(c *cobra.Command, args []string) error {
+		return nil
 	},
 }


### PR DESCRIPTION
This will prevent to run buffalo commands outside a buffalo folder by checking `.buffalo.dev.yml` existence.

This doesn't apply for `new` and `version` buffalo's subcommand.