### PR TITLE
Use i18n in index template

### DIFF
--- a/generators/newapp/templates/templates/index.html.tmpl
+++ b/generators/newapp/templates/templates/index.html.tmpl
@@ -133,7 +133,7 @@
         <a href="<%= rootPath() %>"><img src="/assets/images/logo.svg" alt=""></a>
       </div>
       <div class="col-md-9 col-sm-9 col-xs-10 titles">
-        <h1>Welcome to Buffalo (EN) [{{.version}}]</h1>
+        <h1><%= t("welcome_greeting") %> [{{.version}}]</h1>
         <h2>
           <a href="https://github.com/gobuffalo/buffalo"><i class="fa fa-github" aria-hidden="true"></i> https://github.com/gobuffalo/buffalo</a>
         </h2>


### PR DESCRIPTION
I think that since there is an example i18n message in an initialized project, it would be cool for it to be used in the template. My first step to see how _locales_ work was to search where the key is used, but it wasn't. I needed to go through i18n middleware code to see how I should use it, would be much easier for a less Go-savvy user just to see it in place from the beginning.