### PR TITLE
webpack should rely on webpack config not -p flag

### DIFF
--- a/buffalo/cmd/build.go
+++ b/buffalo/cmd/build.go
@@ -59,7 +59,7 @@ func (b *builder) buildWebpack() error {
 	_, err := os.Stat("webpack.config.js")
 	if err == nil {
 		// build webpack
-		return b.exec(webpack.BinPath, "-p")
+		return b.exec(webpack.BinPath)
 	}
 	return nil
 }

--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -1,7 +1,6 @@
 var webpack = require("webpack");
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
-var UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
   entry: [
@@ -28,7 +27,21 @@ module.exports = {
         "js/*",
       ]
     }),
-    new UglifyJSPlugin()
+    new webpack.LoaderOptionsPlugin({
+      minimize: true,
+      debug: false
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      beautify: false,
+      mangle: {
+        screw_ie8: true,
+        keep_fnames: true
+      },
+      compress: {
+        screw_ie8: true
+      },
+      comments: false
+    })
   ],
   module: {
     rules: [{


### PR DESCRIPTION
The `buffalo build` command runs webpack with a `-p` flag, which forces tree shaking and default minification configurations on the project.  This can be a problem for projects with more advance settings, with custom requirements. 

This pull request simply moves the same advantages of a `-p` flag, to the webpack.config.js, making it possible for any user to customise the webpack.config.js, as they see fit, without running into similar limitations.