### PR TITLE
Adding versions to the NPM packages

### DIFF
--- a/generators/assets/webpack/webpack.go
+++ b/generators/assets/webpack/webpack.go
@@ -68,10 +68,28 @@ func New(data makr.Data) (*makr.Generator, error) {
 	c := makr.NewCommand(exec.Command(command, "init", "-y"))
 	g.Add(c)
 
-	modules := []string{"webpack@~2.3.0", "sass-loader", "css-loader", "style-loader", "node-sass",
-		"extract-text-webpack-plugin@2.1.2", "babel-cli", "babel-core", "babel-preset-env", "babel-loader", "url-loader",
-		"file-loader", "jquery", "bootstrap", "path", "font-awesome", "npm-install-webpack-plugin", "jquery-ujs",
-		"copy-webpack-plugin", "expose-loader", "uglifyjs-webpack-plugin@~0.4.6",
+	modules := []string{
+		"webpack@~2.3.0",
+		"sass-loader@~6.0.5",
+		"css-loader@~0.28.4",
+		"expose-loader@~0.7.3",
+		"style-loader@~0.18.2",
+		"node-sass@~4.5.3",
+		"extract-text-webpack-plugin@2.1.2",
+		"babel-cli@~6.24.1",
+		"babel-core@~6.25.0",
+		"babel-preset-env@~1.5.2",
+		"babel-loader@~7.0.0",
+		"url-loader@~0.5.9",
+		"file-loader@~0.11.2",
+		"jquery@~3.2.1",
+		"bootstrap@~3.3.7",
+		"path@~0.12.7",
+		"font-awesome@~4.7.0",
+		"npm-install-webpack-plugin@4.0.4",
+		"jquery-ujs@~1.2.2",
+		"copy-webpack-plugin@~4.0.1",
+		"uglifyjs-webpack-plugin@~0.4.6",
 	}
 
 	args = append(args, modules...)


### PR DESCRIPTION
Given we've seen issues where some webpack/node package change and newly created buffalo app stop working we need to ensure our versions are stablished when generating the package.json file.

This PR sets these versions leaving room for minor changes in the packages.