### PR TITLE
Fix resource generation example message

### DIFF
--- a/buffalo/cmd/generate/resource.go
+++ b/buffalo/cmd/generate/resource.go
@@ -37,7 +37,7 @@ Generates:
 - actions/users.go
 - actions/users_test.go
 
-$ buffalo g resource users --use-model
+$ buffalo g resource users --use-model users
 Generates:
 
 - actions/users.go


### PR DESCRIPTION
The example is missing the required argument.