### PR TITLE
Fix panic on path permissions issue

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -37,6 +37,10 @@ func Available() (List, error) {
 			continue
 		}
 		err := filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				// May indicate a permissions problem with the path, skip it
+				return nil	
+			}
 			if info.IsDir() {
 				return nil
 			}


### PR DESCRIPTION
If a directory in the path has the incorrect permissions, the `info` variable will be `nil`, causing a panic.

I figured it would be better to just skip that directory.