### PR TITLE
Routes escape extra args

### DIFF
--- a/route.go
+++ b/route.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -115,7 +116,7 @@ func addExtraParamsTo(path string, opts map[string]interface{}) string {
 			format = "&%v=%v"
 		}
 
-		path = path + fmt.Sprintf(format, k, pendingParams[k])
+		path = path + fmt.Sprintf(format, url.QueryEscape(k), url.QueryEscape(pendingParams[k]))
 		index = index + 1
 	}
 

--- a/router_test.go
+++ b/router_test.go
@@ -170,6 +170,8 @@ func Test_App_NamedRoutes(t *testing.T) {
 			8. <%= editCarPath({car_id: 1}) %>
 			9. <%= editCarPath({car_id: 1, other: 12}) %>
 			10. <%= rootPath({"some":"variable","other": 12}) %>
+			11. <%= rootPath() %>
+			12. <%= rootPath({"special/":"12=ss"}) %>
 		`))
 	}
 
@@ -193,6 +195,8 @@ func Test_App_NamedRoutes(t *testing.T) {
 	r.Contains(res.Body.String(), "8. /car/1/edit")
 	r.Contains(res.Body.String(), "9. /car/1/edit?other=12")
 	r.Contains(res.Body.String(), "10. /?other=12&some=variable")
+	r.Contains(res.Body.String(), "11. /")
+	r.Contains(res.Body.String(), "12. /?special%2F=12%3Dss")
 }
 
 func Test_Resource(t *testing.T) {


### PR DESCRIPTION
Extra arguments (not named) passed to the route helpers should be escaped.