### PR TITLE
fixed unwanted trailing query-sign and repeated reassignment

### DIFF
--- a/route.go
+++ b/route.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -95,7 +96,15 @@ func addExtraParamsTo(path string, opts map[string]interface{}) string {
 		}
 
 		keys = append(keys, k)
-		pendingParams[k] = fmt.Sprintf("%v", v)
+		if str, ok := v.(string); ok {
+			pendingParams[k] = fmt.Sprintf("%v", url.QueryEscape(str))
+		} else {
+			pendingParams[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	if len(keys) == 0 {
+		return path
 	}
 
 	if strings.Contains(path, "?") == false {
@@ -109,10 +118,10 @@ func addExtraParamsTo(path string, opts map[string]interface{}) string {
 	sort.Strings(keys)
 
 	for index, k := range keys {
-		format := "%v=%v"
+		format := "&%v=%v"
 
-		if index > 0 {
-			format = "&%v=%v"
+		if index == 0 {
+			format = "%v=%v"
 		}
 
 		path = path + fmt.Sprintf(format, k, pendingParams[k])


### PR DESCRIPTION
Hi, recently new function `addExtraParamsTo` was added and it very cool! but currently, it makes extra query sign(`?`) in end of all generated URL even if there is no extra options. I fixed that with simple length checking of pendingParams's key list.

Additionally, since it called from template, query escaping is somewhat annoying. I just added query escaping for string type into same commit.

Last part of the `diff` is just speed up in mind :-) There is only one 'the first' element on the array, so reassign to the first is more cheaper than reassign to the others.

Please check and consider the pull request.