### PR TITLE
Skip the windows directory when looking for plugins

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -26,6 +26,9 @@ type List map[string]Commands
 // * file/command must start with `buffalo-`
 // * file/command must respond to `available` and return JSON of
 //	 plugins.Commands{}
+//
+// Caveats:
+// * The C:\Windows directory is excluded
 func Available() (List, error) {
 	list := List{}
 	paths := []string{"plugins"}
@@ -35,6 +38,9 @@ func Available() (List, error) {
 		paths = append(paths, strings.Split(os.Getenv("PATH"), ":")...)
 	}
 	for _, p := range paths {
+		if strings.HasPrefix(strings.ToLower(p), `c:\windows`) {
+			continue	
+		}
 		if _, err := os.Stat(p); err != nil {
 			continue
 		}


### PR DESCRIPTION
The buffalo command can seemingly hang when looking for plugins on some Windows systems. The `%PATH%` could have multiple entries containing `C:\windows` causing multiple file walks of the same directories.

Filewalking that path is fairly expensive, as it has many files and folders, most of which are Windows internals.

Adding this change dropped the startup time from ~30s to less than a second.