### PR TITLE
When fetching packages with go get, remove redundant go install

### DIFF
--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -180,7 +180,7 @@ func init() {
 	RootCmd.AddCommand(newCmd)
 	newCmd.Flags().BoolVar(&app.API, "api", false, "skip all front-end code and configure for an API server")
 	newCmd.Flags().BoolVarP(&app.Force, "force", "f", false, "delete and remake if the app already exists")
-	newCmd.Flags().BoolVarP(&app.Verbose, "verbose", "v", false, "verbosely print out the go get/install commands")
+	newCmd.Flags().BoolVarP(&app.Verbose, "verbose", "v", false, "verbosely print out the go get commands")
 	newCmd.Flags().BoolVar(&app.SkipPop, "skip-pop", false, "skips adding pop/soda to your app")
 	newCmd.Flags().BoolVar(&app.WithDep, "with-dep", false, "adds github.com/golang/dep to your app")
 	newCmd.Flags().BoolVar(&app.SkipWebpack, "skip-webpack", false, "skips adding Webpack to your app")

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -35,11 +35,8 @@ type App struct {
 func (a *App) Generator(data makr.Data) (*makr.Generator, error) {
 	g := makr.New()
 	g.Add(makr.NewCommand(makr.GoGet("golang.org/x/tools/cmd/goimports", "-u")))
-	g.Add(makr.NewCommand(makr.GoInstall("golang.org/x/tools/cmd/goimports")))
 	g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep/cmd/dep", "-u")))
-	g.Add(makr.NewCommand(makr.GoInstall("github.com/golang/dep/cmd/dep")))
 	g.Add(makr.NewCommand(makr.GoGet("github.com/motemen/gore", "-u")))
-	g.Add(makr.NewCommand(makr.GoInstall("github.com/motemen/gore")))
 
 	files, err := generators.Find("newapp")
 	if err != nil {

--- a/generators/newapp/soda.go
+++ b/generators/newapp/soda.go
@@ -31,10 +31,6 @@ func newSodaGenerator() *makr.Generator {
 	c.Should = should
 	g.Add(c)
 
-	c = makr.NewCommand(makr.GoInstall("github.com/markbates/pop/soda"))
-	c.Should = should
-	g.Add(c)
-
 	g.Add(&makr.Func{
 		Should: should,
 		Runner: func(rootPath string, data makr.Data) error {


### PR DESCRIPTION
"go get" fetches and installs the specified package according to the
documentation:

    Get downloads the packages named by the import paths, along with their
    dependencies. It then installs the named packages, like 'go install'.

Testing this myself on go1.8.3 and go1.9rc2 having an older version of
buffalo binary install, then running:

    go get -u github.com/gobuffalo/buffalo/...

Shows the binary is also updated successfully when checking the version.

Relates to documentation update: https://github.com/gobuffalo/gobuffalo/pull/57

Further, this appears to have first started with https://github.com/gobuffalo/buffalo/commit/1bcb98153c42d8c0c2c1243c02c5338ca2c55886#diff-00e5b9d3695f2772e4d4422b4fee4787R92 where there's a `glide get` of `github.com/markbates/refresh` followed by `go install` of the same package. Could this have initially been a `glide` vs `go` behaviour difference that continued through the various refactors? But it seems safe to remove the additional `go install` now.

I have tested this on a basic `buffalo new <name>`, but I haven't extensively tested this change in regards to the soda related changes or Dockerfile.
