### PR TITLE
Added Body print capabilities to ParamLogger if the request is application/json

### DIFF
--- a/middleware/param_logger.go
+++ b/middleware/param_logger.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/json"
+	"io/ioutil"
 
 	"github.com/gobuffalo/buffalo"
 )
@@ -12,9 +13,16 @@ func ParameterLogger(next buffalo.Handler) buffalo.Handler {
 		defer func() {
 			req := c.Request()
 			if req.Method != "GET" {
-				b, err := json.Marshal(req.Form)
-				if err == nil {
-					c.LogField("form", string(b))
+				if req.Header.Get("Content-Type") == "application/json" {
+					b, err := ioutil.ReadAll(req.Body)
+					if err == nil {
+						c.LogField("body", string(b))
+					}
+				} else {
+					b, err := json.Marshal(req.Form)
+					if err == nil {
+						c.LogField("form", string(b))
+					}
 				}
 			}
 			b, err := json.Marshal(c.Params())


### PR DESCRIPTION
While using Buffalo for developing an API, I found myself in the need of inspecting the JSON POST requests in order to detect some anomalies, and I was surprised that the ParamLogger printed the URL, the FORM and the QueryString params, but didn't print the body of the POST requests that weren't FormUrlEncoded.

This Pull Request adds a check to detect if the request has a Content-Type of "application/json", and if it has, it dumps the JSON. Otherwise, it's assumed that it's a FormUrlEncoded request and prints the Form as it did before.