### PR TITLE
Enable plugin subcommands

### DIFF
--- a/buffalo/cmd/plugins.go
+++ b/buffalo/cmd/plugins.go
@@ -49,6 +49,7 @@ func decorate(name string, cmd *cobra.Command) {
 
 					ax = append(ax, args...)
 					ex := exec.Command(c.Binary, ax...)
+					ex.Env = append(os.Environ(), "BUFFALO_PLUGIN=1")
 					ex.Stdin = os.Stdin
 					ex.Stdout = os.Stdout
 					ex.Stderr = os.Stderr

--- a/buffalo/cmd/plugins.go
+++ b/buffalo/cmd/plugins.go
@@ -37,7 +37,16 @@ func decorate(name string, cmd *cobra.Command) {
 				Short:   fmt.Sprintf("[PLUGIN] %s", c.Description),
 				Aliases: c.Aliases,
 				RunE: func(cmd *cobra.Command, args []string) error {
-					ax := []string{c.Name}
+					plugCmd := c.Name
+					if c.UseCommand != "" {
+						plugCmd = c.UseCommand
+					}
+
+					ax := []string{plugCmd}
+					if plugCmd == "-" {
+						ax = []string{}
+					}
+
 					ax = append(ax, args...)
 					ex := exec.Command(c.Binary, ax...)
 					ex.Stdin = os.Stdin

--- a/plugins/command.go
+++ b/plugins/command.go
@@ -4,6 +4,8 @@ package plugins
 type Command struct {
 	// Name "foo"
 	Name string `json:"name"`
+	// UseCommand "bar"
+	UseCommand string `json:"use_command"`
 	// BuffaloCommand "generate"
 	BuffaloCommand string `json:"buffalo_command"`
 	// Description "generates a foo"


### PR DESCRIPTION
This adds a few features that may be helpful:

Let the plugin confirm that it's running as a buffalo plugin via the ENV variable BUFFALO_PLUGIN.

This helps when the plugins can be used directly on their own, potentially even in scenarios where buffalo isn't installed. It also makes it easier to build ops/ci tools since buffalo doesn't need to be installed just for something like deploying from a pipeline.

Let the bare plugin binary provide the actual functionality by setting UseCommand = "-".

This makes it easier to use things like shell scripts as plugins. The bare script can provide the actual functionality and then script only needs to implement the Plugin interface (the available command).

It also means that plugins can expose functionality that lives at their root without requiring a subcommand just for buffalo.

Allow the name used when operating as a plugin to be different from the name used when executing the plugin directly.

This makes it easier to provide shims to existing tools to let them have something like a shell script that adapts the application to work as a plugin.