### PR TITLE
fix for gorilla context memory leak

### DIFF
--- a/app.go
+++ b/app.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"syscall"
 
-	gcontext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	"github.com/markbates/refresh/refresh/web"
 	"github.com/markbates/sigtx"
@@ -101,7 +100,6 @@ func (a *App) Stop(err error) error {
 }
 
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer gcontext.Clear(r)
 	ws := &Response{
 		ResponseWriter: w,
 	}

--- a/handler.go
+++ b/handler.go
@@ -3,6 +3,7 @@ package buffalo
 import (
 	"net/http"
 
+	gcontext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
@@ -63,6 +64,7 @@ func (a *App) newContext(info RouteInfo, res http.ResponseWriter, req *http.Requ
 }
 
 func (info RouteInfo) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	defer gcontext.Clear(req)
 	a := info.App
 
 	c := a.newContext(info, res, req)


### PR DESCRIPTION
After using the `Null` session I noticed that memory usage dropped considerably.  This lead to looking into memory usage of a fresh buffalo app (`buffalo new --api --skip-pop memtest`) and found that memory usage grows with each request and it's related to the gorilla context / session code.  They call out several memory issues related to the shallow copy of the request when mixing gorilla context with go context.  This PR moves the gorilla `context.Clear` to the buffalo handler before it creates it's own context.

http://www.gorillatoolkit.org/pkg/sessions
https://github.com/gorilla/sessions/pull/110

Screenshot is from a heap after 200k requests to the default home controller -- after the change these nodes were no longer present.
<img width="372" alt="screen shot 2017-09-05 at 11 56 52 am" src="https://user-images.githubusercontent.com/56036/30075737-ef3036b4-9233-11e7-88d3-724f44a0adab.png">

NewRelic goagent shows the memory growth during load test:
<img width="750" alt="screen shot 2017-09-05 at 8 17 13 am" src="https://user-images.githubusercontent.com/56036/30075828-33dcf504-9234-11e7-9bbf-49e20bbb88a7.png">

After the fix the load test shows stable memory usage:
<img width="749" alt="screen shot 2017-09-05 at 12 18 40 pm" src="https://user-images.githubusercontent.com/56036/30075894-75aadc62-9234-11e7-8308-dd40a6e67e35.png">
