### PR TITLE
add new option to not override url names

### DIFF
--- a/options.go
+++ b/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	Context context.Context
 	cancel  context.CancelFunc
 	Prefix  string
+	URLNameOverride bool
 }
 
 // PreWare takes an http.Handler and returns and http.Handler

--- a/router.go
+++ b/router.go
@@ -106,6 +106,10 @@ func (a *App) ServeFiles(p string, root http.FileSystem) {
 */
 func (a *App) Resource(p string, r Resource) *App {
 	g := a.Group(p)
+
+	// Set Option
+	g.URLNameOverride = a.URLNameOverride
+
 	p = "/"
 
 	rv := reflect.ValueOf(r)
@@ -215,6 +219,14 @@ func (a *App) buildRouteName(p string) string {
 
 	resultParts := []string{}
 	parts := strings.Split(p, "/")
+
+	if a.URLNameOverride {
+		if a.root == nil && a.Prefix == p {
+			return "root"
+		} else if (a.root != nil && a.root.Prefix != p) || p != a.Prefix {
+			parts = append(parts[:1], parts[1+1:]...)
+		}
+	}
 
 	for index, part := range parts {
 

--- a/router_test.go
+++ b/router_test.go
@@ -428,6 +428,67 @@ func Test_Resource(t *testing.T) {
 
 }
 
+func Test_ResourceNameOverride(t *testing.T) {
+	type CarsResource struct {
+		*BaseResource
+	}
+
+	r := require.New(t)
+	a := Automatic(Options{Prefix: "/test"})
+	a.URLNameOverride = true
+
+	var carsResource Resource
+	carsResource = CarsResource{&BaseResource{}}
+
+	rr := render.New(render.Options{
+		HTMLLayout:     "application.html",
+		TemplateEngine: plush.BuffaloRenderer,
+		TemplatesBox:   packr.NewBox("../templates"),
+		Helpers:        map[string]interface{}{},
+	})
+
+	sampleHandler := func(c Context) error {
+		c.Set("opts", map[string]interface{}{})
+		return c.Render(200, rr.String(`
+			1. <%= rootPath() %>
+			2. <%= usersPath() %>
+			3. <%= userPath({user_id: 1}) %>
+			4. <%= myPeepsPath() %>
+			5. <%= userPath(opts) %>
+			6. <%= carPath({car_id: 1}) %>
+			7. <%= newCarPath() %>
+			8. <%= editCarPath({car_id: 1}) %>
+			9. <%= editCarPath({car_id: 1, other: 12}) %>
+			10. <%= rootPath({"some":"variable","other": 12}) %>
+			11. <%= rootPath() %>
+			12. <%= rootPath({"special/":"12=ss"}) %>
+		`))
+	}
+
+	a.GET("/", sampleHandler)
+	a.GET("/users", sampleHandler)
+	a.GET("/users/{user_id}", sampleHandler)
+	a.GET("/peeps", sampleHandler).Name("myPeeps")
+	a.Resource("/car", carsResource)
+
+	w := willie.New(a)
+	res := w.Request("/test").Get()
+
+	r.Equal(200, res.Code)
+	r.Contains(res.Body.String(), "1. /test")
+	r.Contains(res.Body.String(), "2. /test/users")
+	r.Contains(res.Body.String(), "3. /test/users/1")
+	r.Contains(res.Body.String(), "4. /test/peeps")
+	r.Contains(res.Body.String(), "5. /test/users/{user_id}")
+	r.Contains(res.Body.String(), "6. /test/car/1")
+	r.Contains(res.Body.String(), "7. /test/car/new")
+	r.Contains(res.Body.String(), "8. /test/car/1/edit")
+	r.Contains(res.Body.String(), "9. /test/car/1/edit?other=12")
+	r.Contains(res.Body.String(), "10. /test?other=12&some=variable")
+	r.Contains(res.Body.String(), "11. /test")
+	r.Contains(res.Body.String(), "12. /test?special%2F=12%3Dss")
+}
+
 type userResource struct{}
 
 func (u *userResource) List(c Context) error {


### PR DESCRIPTION
Hey @markbates,

that is some kind of an idea to make it possible to reuse the same url names even though you may be running the root app with a prefix. Not sure if it's good, but it works out at least :)

Looking forward to your feedback!