### PR TITLE
refactored app.Start to gracefully shutdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,13 +3,16 @@ package buffalo
 import (
 	"context"
 	"fmt"
+	"net"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/markbates/refresh/refresh/web"
@@ -30,6 +33,8 @@ type App struct {
 	routes        RouteList
 	root          *App
 	children      []*App
+	server        http.Server
+	closed        bool
 }
 
 // Start the application at the specified address/port and listen for OS
@@ -39,23 +44,62 @@ func (a *App) Start(addr string) error {
 	if !strings.Contains(addr, ":") {
 		addr = fmt.Sprintf(":%s", addr)
 	}
-	fmt.Printf("Starting application at %s\n", addr)
-	server := http.Server{
-		Addr:    addr,
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		a.Stop(err)
+	}
+
+	fmt.Printf("Starting application at %s:%d\n",
+		listener.Addr().(*net.TCPAddr).IP,
+		listener.Addr().(*net.TCPAddr).Port)
+
+	a.moot.Lock()
+	a.server = http.Server{
+		Addr:    listener.Addr().String(),
 		Handler: a,
 	}
-	ctx, cancel := sigtx.WithCancel(a.Context, syscall.SIGTERM, os.Interrupt)
-	defer cancel()
+	a.moot.Unlock()
 
+	// if configured to do so, start the workers
+	if !a.WorkerOff {
+		go func() {
+			ctx, cancel := sigtx.WithCancel(a.Context, syscall.SIGTERM, os.Interrupt)
+			defer cancel()
+			err := a.Worker.Start(ctx)
+			if err != nil {
+				a.Stop(err)
+			}
+		}()
+	}
+
+	errChan := make(chan error)
 	go func() {
-		// gracefully shut down the application when the context is cancelled
-		<-ctx.Done()
-		fmt.Println("Shutting down application")
+		errChan <- a.server.Serve(listener)
+	}()
 
-		err := a.Stop(ctx.Err())
-		if err != nil {
-			fmt.Println(err)
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGTERM, os.Interrupt)
+
+	for {
+		select {
+		case err := <-errChan:
+			return a.Stop(err)
+		case <-signalChan:
+			return a.Stop(nil)
 		}
+	}
+}
+
+// Stop the application and attempt to gracefully shutdown
+func (a *App) Stop(err error) error {
+	a.moot.Lock()
+	defer a.moot.Unlock()
+	if !a.closed {
+		fmt.Println("Shutting down application")
+		a.closed = true
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Duration(a.ShutDownTimeoutSeconds)*time.Second)
+		defer cancel()
+		a.server.Shutdown(shutdownCtx)
 
 		if !a.WorkerOff {
 			// stop the workers
@@ -66,37 +110,11 @@ func (a *App) Start(addr string) error {
 			}
 		}
 
-		err = server.Shutdown(ctx)
-		if err != nil {
+		a.cancel()
+		if err != nil && errors.Cause(err) != context.Canceled {
 			fmt.Println(err)
+			return err
 		}
-
-	}()
-
-	// if configured to do so, start the workers
-	if !a.WorkerOff {
-		go func() {
-			err := a.Worker.Start(ctx)
-			if err != nil {
-				a.Stop(err)
-			}
-		}()
-	}
-
-	// start the web server
-	err := server.ListenAndServe()
-	if err != nil {
-		return a.Stop(err)
-	}
-	return nil
-}
-
-// Stop the application and attempt to gracefully shutdown
-func (a *App) Stop(err error) error {
-	a.cancel()
-	if err != nil && errors.Cause(err) != context.Canceled {
-		fmt.Println(err)
-		return err
 	}
 	return nil
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1,5 +1,83 @@
 package buffalo
 
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
 func voidHandler(c Context) error {
 	return nil
+}
+
+func getDynamicPort(a *App) string {
+	a.moot.Lock()
+	defer a.moot.Unlock()
+	_, port, _ := net.SplitHostPort(a.server.Addr)
+	return port
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	requestFinished := false
+	app := New(NewOptions())
+	app.WorkerOff = true
+	app.GET("/slow", func(c Context) error {
+		time.Sleep(1 * time.Second)
+		requestFinished = true
+		return nil
+	})
+
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	}()
+
+	go func() {
+		time.Sleep(750 * time.Millisecond)
+		port := getDynamicPort(app)
+		_, err := http.Get(fmt.Sprintf("http://localhost:%s/slow", port))
+		if err != nil {
+			t.Error("unexpected error requesting slow endpoint", err)
+		}
+	}()
+
+	app.Start("127.0.0.1:0")
+
+	require.True(t, requestFinished, "expected request to finish but was terminated early")
+}
+
+func TestGracefulShutdown_ForcedShutdown(t *testing.T) {
+	requestFinished := false
+
+	app := New(NewOptions())
+	app.WorkerOff = true
+	app.ShutDownTimeoutSeconds = 1
+	app.GET("/slow", func(c Context) error {
+		time.Sleep(4 * time.Second)
+		requestFinished = true
+		return nil
+	})
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		app.Stop(nil)
+	}()
+
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		port := getDynamicPort(app)
+		_, err := http.Get(fmt.Sprintf("http://localhost:%s/slow", port))
+		if err != nil {
+			t.Error("unexpected error requesting slow endpoint", err)
+		}
+	}()
+
+	app.Start("127.0.0.1:0")
+
+	require.False(t, requestFinished, "expected request to be terminated early")
 }

--- a/options.go
+++ b/options.go
@@ -52,6 +52,10 @@ type Options struct {
 	Context context.Context
 	cancel  context.CancelFunc
 	Prefix  string
+
+	// ShutDownTimeoutSeconds is used to cap the time spent waiting for requests to finish after application
+	// receives SIGTERM or SIGINT.  Default 30 seconds.
+	ShutDownTimeoutSeconds int
 }
 
 // PreWare takes an http.Handler and returns and http.Handler
@@ -115,5 +119,6 @@ func optionsWithDefaults(opts Options) Options {
 	}
 	opts.SessionName = defaults.String(opts.SessionName, "_buffalo_session")
 	opts.Host = defaults.String(opts.Host, envy.Get("HOST", fmt.Sprintf("http://127.0.0.1:%s", envy.Get("PORT", "3000"))))
+	opts.ShutDownTimeoutSeconds = defaults.Int(opts.ShutDownTimeoutSeconds, 30)
 	return opts
 }


### PR DESCRIPTION
Noticed that requests aren't allowed to finish durning shutdown even though `server.Shutdown` was called.  This was due to `ListenAndServe` returning once the shutdown starts, this causes the application to terminate.

This basically flips the functionality that was in a goroutine in `app.Start` adding a channel to get errors from `ListenAndServe` and making the timeout for shutdown configurable.  This only applies to http requests finishing, if there are no open connections but the worker is active the application will still exit immediately.

Test verifies correct shutdown behavior by actually starting the application -- guessing there is a much better and less brittle way to verify.