### PR TITLE
App binds to 127.0.0.1:3000 by default

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -33,13 +32,10 @@ type App struct {
 // Start the application at the specified address/port and listen for OS
 // interrupt and kill signals and will attempt to stop the application
 // gracefully. This will also start the Worker process, unless WorkerOff is enabled.
-func (a *App) Start(addr string) error {
-	if !strings.Contains(addr, ":") {
-		addr = fmt.Sprintf(":%s", addr)
-	}
-	fmt.Printf("Starting application at %s\n", addr)
+func (a *App) Start() error {
+	fmt.Printf("Starting application at %s\n", a.Options.Addr)
 	server := http.Server{
-		Addr:    addr,
+		Addr:    a.Options.Addr,
 		Handler: a,
 	}
 	ctx, cancel := sigtx.WithCancel(a.Context, syscall.SIGTERM, os.Interrupt)

--- a/generators/newapp/templates/main.go.tmpl
+++ b/generators/newapp/templates/main.go.tmpl
@@ -4,11 +4,9 @@ import (
 	"log"
 
   "{{ .opts.ActionsPkg }}"
-  "github.com/gobuffalo/envy"
 )
 
 func main() {
-	port := envy.Get("PORT", "3000")
 	app := actions.App()
-	log.Fatal(app.Start(port))
+	log.Fatal(app.Start())
 }

--- a/options.go
+++ b/options.go
@@ -17,6 +17,8 @@ import (
 // Options are used to configure and define how your application should run.
 type Options struct {
 	Name string
+	// Addr is the bind address provided to http.Server
+	Addr string
 	// Env is the "environment" in which the App is running. Default is "development".
 	Env string
 	// LogLevel defaults to "debug".
@@ -65,6 +67,7 @@ func NewOptions() Options {
 }
 
 func optionsWithDefaults(opts Options) Options {
+	opts.Addr = defaults.String(opts.Addr, fmt.Sprintf("%s:%s", envy.Get("HOST", "127.0.0.1"), envy.Get("PORT", "3000")))
 	opts.Env = defaults.String(opts.Env, envy.Get("GO_ENV", "development"))
 	opts.LogLevel = defaults.String(opts.LogLevel, "debug")
 	opts.Name = defaults.String(opts.Name, "/")


### PR DESCRIPTION
In `options.go`, the `Options.Host` field states the default bind location is `127.0.0.1:3000`. However, this value doesn't seem to be used anywhere in buffalo.

I noticed that I was presented with Mac's firewall prompt every time my buffalo app started. This prompt isn't presented when a program binds to `127.0.0.1` only, so the app must be binding to `0.0.0.0`.

<img width="418" alt="firewall" src="https://user-images.githubusercontent.com/13948507/31857992-d2ae2cea-b6a9-11e7-988d-d5924b759c9c.png">

Rather than use the bind address/port provided to `app.Start()`, this PR adjusts `app.Start()` to use the `Options.Host` value. This should provide the intended behavior from the `Options.Host` description.

It also removes the argument to `app.Start()`, which would be an issue for app upgrades where `main.go` was generated to provide the `addr` argument. 

After building a test project with this change, the app binds to `127.0.0.1:3000` by default. `PORT` can still be overridden as before, and the Mac's firewall prompt no longer pops on app start.