### PR TITLE
Cleaning up stale webpack output.

### DIFF
--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -9,6 +9,7 @@
     "babel-loader": "~7.0.0",
     "babel-preset-env": "~1.5.2",
     "bootstrap-sass": "~3.3.7",
+    "clean-webpack-plugin": "~0.1.17",
     "copy-webpack-plugin": "~4.0.1",
     "css-loader": "~0.28.4",
     "expose-loader": "~0.7.3",

--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -3,6 +3,7 @@ var CopyWebpackPlugin = require("copy-webpack-plugin");
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var ManifestPlugin = require("webpack-manifest-plugin");
 var PROD = process.env.NODE_ENV || "development";
+var CleanWebpackPlugin = require('clean-webpack-plugin')
 
 module.exports = {
   entry: {
@@ -17,6 +18,12 @@ module.exports = {
     path: `${__dirname}/public/assets`
   },
   plugins: [
+    new CleanWebpackPlugin([
+      'public/assets/*.js',
+      'public/assets/*.css'
+    ], {
+      watch: true
+    }),
     new webpack.ProvidePlugin({
       $: "jquery",
       jQuery: "jquery"

--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -3,7 +3,7 @@ var CopyWebpackPlugin = require("copy-webpack-plugin");
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var ManifestPlugin = require("webpack-manifest-plugin");
 var PROD = process.env.NODE_ENV || "development";
-var CleanWebpackPlugin = require('clean-webpack-plugin')
+var CleanWebpackPlugin = require('clean-webpack-plugin');
 
 module.exports = {
   entry: {


### PR DESCRIPTION
Asset fingerprinting was causing `public/assets` to fill up with stale files when running `buffalo dev` and making js/css edits. Added a webpack plugin and config to clean out the js and css output before generating new files.