### PR TITLE
add rate limiter middleware (fix #331)

### DIFF
--- a/middleware/ratelimiter/memory.go
+++ b/middleware/ratelimiter/memory.go
@@ -1,0 +1,58 @@
+package ratelimiter
+
+import "sync"
+
+// implement Counter interface
+var _ Counter = &MemoryCounter{}
+
+// InMemory is a middleware that uses the default options with the MemoryCounter
+var InMemory = Middleware(NewMemoryCounter(), &DefaultOptions)
+
+// MemoryCounter limits calls to the api based on IP
+type MemoryCounter struct {
+	m       *sync.RWMutex
+	counter map[string]int
+}
+
+// NewMemoryCounter creates a new MemoryCounter with default values
+func NewMemoryCounter() *MemoryCounter {
+	return &MemoryCounter{
+		m:       &sync.RWMutex{},
+		counter: map[string]int{},
+	}
+}
+
+// Increment increments the counter for the IP
+func (r *MemoryCounter) Increment(ip string) (count int, err error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.counter[ip]++
+	return r.counter[ip], nil
+}
+
+// Decrement decrements the counter for the IP
+func (r *MemoryCounter) Decrement(ip string) (count int, err error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.counter[ip]--
+	return r.counter[ip], nil
+}
+
+// Count returns the current count
+func (r *MemoryCounter) Count(ip string) (count int, err error) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	return r.counter[ip], nil
+}
+
+// Set sets the ip count
+func (r *MemoryCounter) Set(ip string, count int) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.counter[ip] = count
+	return nil
+}

--- a/middleware/ratelimiter/rate_limiter.go
+++ b/middleware/ratelimiter/rate_limiter.go
@@ -1,0 +1,78 @@
+package ratelimiter
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gobuffalo/buffalo"
+)
+
+// Counter limits the amount of times an IP can run
+type Counter interface {
+	Increment(ip string) (count int, err error)
+	Decrement(ip string) (count int, err error)
+	Count(ip string) (count int, err error)
+	Set(ip string, count int) error
+}
+
+// DefaultOptions is the default configuration for Rate Limiter middleware.
+// By default, it fetches the IP based on IPHeaders
+var DefaultOptions = Options{
+	Operations: 100,
+	Duration:   time.Second,
+	GetIP: func(c buffalo.Context) (ip string, ok bool) {
+		req := c.Request()
+		for _, h := range []string{"X-Real-IP", "X-Client-IP", "X-Forwarded-For", "RemoteAddr"} {
+			ip := req.Header.Get(h)
+			if len(ip) > 0 {
+				return ip, true
+			}
+		}
+		return
+	},
+}
+
+// Options define options for rate-limiter middleware
+type Options struct {
+	// Operations is how many operations per Duration an IP is allowed
+	Operations int
+
+	// Duration is how long to count Operations
+	Duration time.Duration
+
+	// GetIP is the func used to get the IP address from the request
+	GetIP func(c buffalo.Context) (ip string, ok bool)
+}
+
+// Middleware is the http middleware that limits the interactions to the API
+// based on the IP address using the provided Counter
+func Middleware(r Counter, opts *Options) buffalo.MiddlewareFunc {
+	return func(next buffalo.Handler) buffalo.Handler {
+		return func(c buffalo.Context) error {
+			ip, ok := opts.GetIP(c)
+			if !ok {
+				c.Logger().Warn("could not detect IP")
+				return next(c)
+			}
+
+			go func(ip string, opts *Options) {
+				<-time.After(opts.Duration)
+				r.Decrement(ip)
+			}(ip, opts)
+
+			v, err := r.Increment(ip)
+			if err != nil {
+				c.Logger().Errorf("could not increment counter for ip %q: %v", ip, err)
+				return next(c)
+			}
+
+			if v <= opts.Operations {
+				return next(c)
+			}
+
+			c.Logger().WithField("IP", ip).Warn("rate limited")
+			c.Response().WriteHeader(http.StatusTooManyRequests)
+			return nil
+		}
+	}
+}

--- a/middleware/ratelimiter/rate_limiter_test.go
+++ b/middleware/ratelimiter/rate_limiter_test.go
@@ -1,0 +1,102 @@
+package ratelimiter
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/markbates/willie"
+	"github.com/stretchr/testify/assert"
+)
+
+func memoryRateLimiterTestApp() (cnt Counter, app *buffalo.App) {
+	app = buffalo.New(buffalo.Options{})
+	cnt = NewMemoryCounter()
+	opts := DefaultOptions
+	opts.Duration = time.Millisecond * 10
+	app.Use(Middleware(cnt, &opts))
+	app.ANY("/", func(c buffalo.Context) error {
+		c.Response().WriteHeader(http.StatusOK)
+		return nil
+	})
+	return
+}
+
+func TestRateLimiterShouldNotLimitOnFirstRun(t *testing.T) {
+	cnt, app := memoryRateLimiterTestApp()
+	ip := "abcd"
+	cnt.Set(ip, 1)
+
+	w := willie.New(app)
+	req := w.HTML("/")
+	req.Headers["x-real-ip"] = ip
+	resp := req.Get()
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestRateLimiterShouldLimitWhenCounterEqualToLimit(t *testing.T) {
+	cnt, app := memoryRateLimiterTestApp()
+
+	ip := "abcd"
+	cnt.Set(ip, DefaultOptions.Operations)
+
+	w := willie.New(app)
+	req := w.HTML("/")
+	req.Headers["x-real-ip"] = ip
+	resp := req.Get()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+}
+
+func TestRateLimiterShouldLimitWhenCounterOveLimit(t *testing.T) {
+	cnt, app := memoryRateLimiterTestApp()
+
+	ip := "abcd"
+	cnt.Set(ip, DefaultOptions.Operations+1)
+
+	w := willie.New(app)
+	req := w.HTML("/")
+	req.Headers["x-real-ip"] = ip
+	resp := req.Get()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+}
+func TestRateLimiterShouldNotLimitWhenUnknownIP(t *testing.T) {
+	_, app := memoryRateLimiterTestApp()
+
+	w := willie.New(app)
+	req := w.HTML("/")
+	resp := req.Get()
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestRateLimiterShouldIncrementCounter(t *testing.T) {
+	cnt, app := memoryRateLimiterTestApp()
+	ip := "abcd"
+	cnt.Set(ip, 1)
+
+	w := willie.New(app)
+	req := w.HTML("/")
+	req.Headers["x-real-ip"] = ip
+	req.Get()
+
+	n, _ := cnt.Count(ip)
+	assert.Equal(t, 2, n)
+}
+
+func TestRateLimiterShouldDecrementCounter(t *testing.T) {
+	cnt, app := memoryRateLimiterTestApp()
+	ip := "abcd"
+	cnt.Set(ip, 1)
+
+	w := willie.New(app)
+	req := w.HTML("/")
+	req.Headers["x-real-ip"] = ip
+	req.Get()
+	time.Sleep(DefaultOptions.Duration)
+
+	n, _ := cnt.Count(ip)
+	assert.Equal(t, 1, n)
+}

--- a/middleware/ratelimiter/redis.go
+++ b/middleware/ratelimiter/redis.go
@@ -1,0 +1,56 @@
+package ratelimiter
+
+import (
+	"strconv"
+
+	"github.com/go-redis/redis"
+)
+
+// implement Counter interface
+var _ Counter = &RedisCounter{}
+
+// RedisCounter limits calls to the api based on IP
+type RedisCounter struct {
+	c *redis.Client
+}
+
+// NewRedisCounter creates a new RedisCounter with default values
+func NewRedisCounter(c *redis.Client) *RedisCounter {
+	return &RedisCounter{
+		c: c,
+	}
+}
+
+// Increment increments the counter for the IP
+func (r *RedisCounter) Increment(ip string) (count int, err error) {
+	res := r.c.Incr("ratelimit:" + ip)
+	if err := res.Err(); err != nil {
+		return 0, err
+	}
+	return int(res.Val()), nil
+}
+
+// Decrement decrements the counter for the IP
+func (r *RedisCounter) Decrement(ip string) (count int, err error) {
+	res := r.c.Decr("ratelimit:" + ip)
+	if err := res.Err(); err != nil {
+		return 0, err
+	}
+	return int(res.Val()), nil
+}
+
+// Count returns the current count
+func (r *RedisCounter) Count(ip string) (count int, err error) {
+	res := r.c.Get("ratelimit:" + ip)
+	i, err := strconv.Atoi(res.Val())
+	if err != nil {
+		return 0, err
+	}
+	return i, res.Err()
+}
+
+// Set sets the ip count
+func (r *RedisCounter) Set(ip string, count int) error {
+	res := r.c.Set("ratelimit:"+ip, count, 0)
+	return res.Err()
+}


### PR DESCRIPTION
Fix #331 

Currently implemented with an in-memory counter using a `map`. It will work well enough for a single instance deployment, but won't work with a distributed or scaled project. 

I have implemented rate limiter with a Counter interface. This allows using any implementation such as Redis. I implemented Redis in a separate commit so it can be reviewed, but I'm completely find with removing it and putting it in another repository. Adding the Redis implementation adds Redis as a dependency to Buffalo which doesn't seem ideal.

Perhaps it can be implemented in gobuffalo/redis-ratelimiter and if users prefer the Redis solution they could import it into their own projects. 

Either way. I'm open to feedback :) 