### PR TITLE
Clean all assets on compile

### DIFF
--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -19,8 +19,7 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin([
-      "public/assets/*.js",
-      "public/assets/*.css"
+      "public/assets"
     ], {
       verbose: false,
       watch: true
@@ -35,6 +34,7 @@ module.exports = {
         from: "./assets",
         to: ""
       }], {
+        copyUnmodified: true,
         ignore: ["css/**", "js/**"]
       }
     ),


### PR DESCRIPTION
Fix #727 

As described in issue #727, the output directory for assets is not cleaned on builds. This results in stale assets - e.g. assets not in use by the project - to be permanently left in the output directory and furthermore they are included in the compiled binary.

There is a partial solution to this problem in the development branch. See: https://github.com/gobuffalo/buffalo/commit/96baaab5baeff7dc7c5874c4f5447242c98bf259#diff-53399b34c7dfc25ab7dfa0b83d30ce8epack.config.js.tmpl

The issue with this solution is that it only cleans the JS and CSS files. There's two problems with this:

1. If you add files to `assets` that are not JS or CSS files, they are copied to the `public/assets` folder. If you later remove those files from `assets` because you are not using them, they remain in the output directory (`public/assets`) because on JS and CSS are deleted before the build.
2. If you reference files in your JS or CSS files, if the file sizes are large enough, they are extracted and copied to the `public/assets` folder and added to the `public/assets/manifest.json` file (smaller files are base64 encoded). For example, if you import "Font Awesome" into an SCSS file like this `@import "~font-awesome/css/font-awesome.css";`, the font files will be copied to the output directory and referenced in `public/assets/manifest.json`. If you later remove that import statement the font files will be removed from `public/assets/manifest.json` on the next build, but they will forever remain in the output directory.

Since `public/assets` is an output directory and files are copied from `assets` to `public/assets`, it seems to me that best practice would be to never directly add files to `public/assets`, but instead, add them to `assets` and let webpack copy them. If such is the case, the entire output directory can be cleaned before build, guaranteeing that after build, only the files used by the project will be present in the output directory and only the necessary files will be included in the build.

The one potential downside to the solution in this PR is that we need to copy assets from the assets directory on each rebuild, if not the following happens:

1. The assets get copied
2. The webpack build completes
3. File changes trigger rebuild 
4. The output directory is cleaned 
5. Webpack rebuilds
6. Only JS and CSS are in the output directory

If we re-copy the assets on each rebuild, then the following happens:

1. The assets get copied
2. The webpack build completes
3. File changes trigger rebuild
4. The output directory is cleaned
5. Webpack rebuilds and the assets are copied again
7. All the files used by the project are in the output directory.

With the changes here we get the correct behavior.