### PR TITLE
Fixing underscored multi word resource generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,9 @@ RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/g
 RUN buffalo g resource admin/users --name=AdminUser
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/generate_resource_nested_model_name.json
 
+RUN buffalo g resource person_data
+RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/generate_underscore.json
+
 RUN rm -rf bin
 RUN buffalo build -k -e
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/no_assets_build.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/g
 RUN buffalo g resource admin/users --name=AdminUser
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/generate_resource_nested_model_name.json
 
-RUN buffalo g resource person_data
+RUN buffalo g resource person_event
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/generate_underscore.json
 
 RUN rm -rf bin

--- a/buffalo/cmd/filetests/generate_nested_task.json
+++ b/buffalo/cmd/filetests/generate_nested_task.json
@@ -3,7 +3,7 @@
   "contains": [
     "var _ = Namespace(\"nested\", func() {",
     "Namespace(\"task\", func() {",
-    "Desc(\"now\", \"TODO\")",
+    "Desc(\"now\", \"Task Description\")",
     "Add(\"now\", func(c *Context) error {",
     "return nil"
   ]

--- a/buffalo/cmd/filetests/generate_plain_task.json
+++ b/buffalo/cmd/filetests/generate_plain_task.json
@@ -1,7 +1,7 @@
 [{
   "path": "grifts/plain_task.go",
   "contains": [
-    "var _ = Desc(\"plain_task\", \"TODO\")",
+    "var _ = Desc(\"plain_task\", \"Task Description\")",
     "var _ = Add(\"plain_task\", func(c *Context) error {",
     "return nil"
   ]

--- a/buffalo/cmd/filetests/generate_underscore.json
+++ b/buffalo/cmd/filetests/generate_underscore.json
@@ -1,5 +1,5 @@
 [{
-    "path": "actions/person_data.go",
+    "path": "actions/person_event.go",
     "contains": [
       "c.Set(\"personEvents\", personEvents)",
       "c.Set(\"personEvent\", personEvent)"

--- a/buffalo/cmd/filetests/generate_underscore.json
+++ b/buffalo/cmd/filetests/generate_underscore.json
@@ -1,5 +1,5 @@
 [{
-    "path": "actions/person_event.go",
+    "path": "actions/person_events.go",
     "contains": [
       "c.Set(\"personEvents\", personEvents)",
       "c.Set(\"personEvent\", personEvent)"

--- a/buffalo/cmd/filetests/generate_underscore.json
+++ b/buffalo/cmd/filetests/generate_underscore.json
@@ -1,0 +1,8 @@
+[{
+    "path": "actions/person_data.go",
+    "contains": [
+      "c.Set(\"personEvents\", personEvents)",
+      "c.Set(\"personEvent\", personEvent)"
+    ]
+  }
+]

--- a/generators/grift/templates.go
+++ b/generators/grift/templates.go
@@ -11,7 +11,7 @@ const tmplBody = `
 {{ if .opts.Namespaced }}
 		{{ range $index, $element := .opts.Parts }}
 			{{ if $.opts.Last $element}}
-				Desc("{{$element.File}}", "TODO")
+				Desc("{{$element.File}}", "Task Description")
 				Add("{{$element.File}}", func(c *Context) error{
 						return nil
 				})
@@ -27,7 +27,7 @@ const tmplBody = `
 				{{ if $index }} }) {{ end }}
 		{{ end }}
 {{ else }}
-		var _ = Desc("{{.opts.Name.File}}", "TODO")
+		var _ = Desc("{{.opts.Name.File}}", "Task Description")
 		var _ = Add("{{.opts.Name.File}}", func(c *Context) error {
 				return nil
 		})

--- a/generators/resource/templates/actions/resource-use_model.go.tmpl
+++ b/generators/resource/templates/actions/resource-use_model.go.tmpl
@@ -43,7 +43,7 @@ func (v {{.opts.Name.Resource}}Resource) List(c buffalo.Context) error {
   }
 
   // Make {{.opts.Model.ModelPlural}} available inside the html template
-  c.Set("{{.opts.Model.PluralUnder}}", {{.opts.Model.VarCasePlural}})
+  c.Set("{{.opts.Model.VarCasePlural}}", {{.opts.Model.VarCasePlural}})
 
   // Add the paginator to the context so it can be used in the template.
   c.Set("pagination", q.Paginator)
@@ -66,7 +66,7 @@ func (v {{.opts.Name.Resource}}Resource) Show(c buffalo.Context) error {
   }
 
   // Make {{.opts.Model.VarCaseSingular}} available inside the html template
-  c.Set("{{.opts.Model.UnderSingular}}", {{.opts.Model.VarCaseSingular}})
+  c.Set("{{.opts.Model.VarCaseSingular}}", {{.opts.Model.VarCaseSingular}})
 
   return c.Render(200, r.HTML("{{.opts.FilesPath}}/show.html"))
 }
@@ -75,7 +75,7 @@ func (v {{.opts.Name.Resource}}Resource) Show(c buffalo.Context) error {
 // This function is mapped to the path GET /{{.opts.Name.URL}}/new
 func (v {{.opts.Name.Resource}}Resource) New(c buffalo.Context) error {
   // Make {{.opts.Model.VarCaseSingular}} available inside the html template
-  c.Set("{{.opts.Model.UnderSingular}}", &models.{{.opts.Model.Model}}{})
+  c.Set("{{.opts.Model.VarCaseSingular}}", &models.{{.opts.Model.Model}}{})
 
   return c.Render(200, r.HTML("{{.opts.FilesPath}}/new.html"))
 }
@@ -133,7 +133,7 @@ func (v {{.opts.Name.Resource}}Resource) Edit(c buffalo.Context) error {
   }
 
   // Make {{.opts.Model.VarCaseSingular}} available inside the html template
-  c.Set("{{.opts.Model.UnderSingular}}", {{.opts.Model.VarCaseSingular}})
+  c.Set("{{.opts.Model.VarCaseSingular}}", {{.opts.Model.VarCaseSingular}})
   return c.Render(200, r.HTML("{{.opts.FilesPath}}/edit.html"))
 }
 

--- a/middleware/i18n/i18n.go
+++ b/middleware/i18n/i18n.go
@@ -30,10 +30,10 @@ type Translator struct {
 	// default is "lang"
 	SessionName string
 	// HelperName - name of the view helper. default is "t"
-	HelperName     string
+	HelperName string
 	// HelperNamePlural - name of the view plural helper. default is "tp"
 	HelperNamePlural string
-	LanguageFinder LanguageFinder
+	LanguageFinder   LanguageFinder
 }
 
 // Load translations from the t.Box.


### PR DESCRIPTION
Makes actions set the correct variable name when generating resources and the user has passed underscored name on the resource name.

This closes #734 