### PR TITLE
Proper model generation for XML type.

### DIFF
--- a/buffalo/cmd/generate/resource.go
+++ b/buffalo/cmd/generate/resource.go
@@ -46,7 +46,7 @@ func init() {
 	ResourceCmd.Flags().BoolVarP(&resourceOptions.SkipMigration, "skip-migration", "s", false, "sets resource generator not-to add model migration")
 	ResourceCmd.Flags().BoolVarP(&resourceOptions.SkipModel, "skip-model", "", false, "makes resource generator not to generate model nor migrations")
 	ResourceCmd.Flags().StringVarP(&resourceOptions.Name, "name", "n", "", "allows to define a different model name for the resource being generated.")
-	ResourceCmd.Flags().StringVarP(&resourceOptions.MimeType, "type", "", "html", "sets the resource type (html or json)")
+	ResourceCmd.Flags().StringVarP(&resourceOptions.MimeType, "type", "", "html", "sets the resource type (html, json, xml)")
 }
 
 const resourceExamples = `$ buffalo g resource users

--- a/generators/resource/resource.go
+++ b/generators/resource/resource.go
@@ -78,5 +78,10 @@ func (res Generator) modelCommand() makr.Command {
 	if res.SkipMigration {
 		args = append(args, "--skip-migration")
 	}
+
+	if res.MimeType == "JSON" || res.MimeType == "XML" {
+		args = append(args, "--struct-tag", strings.ToLower(res.MimeType))
+	}
+
 	return makr.NewCommand(exec.Command("buffalo", args...))
 }


### PR DESCRIPTION
Use soda --struct-tag argument to generate model with proper struct tags.
Previously JSON was always hardcoded.

Related change: https://github.com/markbates/pop/pull/153

Some XML support was added in PR https://github.com/gobuffalo/buffalo/pull/390 but didn't affect struct tags in a model.