### PR TITLE
WIP adding the concept of a scope to resources

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/websocket"
+	"github.com/markbates/pop"
 
 	"github.com/gobuffalo/buffalo/render"
 )
@@ -32,6 +33,8 @@ type Context interface {
 	Redirect(int, string, ...interface{}) error
 	Data() map[string]interface{}
 	Flash() *Flash
+	Scope() *pop.Query
+	DB() *pop.Connection
 }
 
 // ParamValues will most commonly be url.Values,

--- a/default_context.go
+++ b/default_context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gobuffalo/buffalo/binding"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gorilla/websocket"
+	"github.com/markbates/pop"
 	"github.com/pkg/errors"
 )
 
@@ -197,6 +198,30 @@ func (d *DefaultContext) String() string {
 	}
 	sort.Strings(bb)
 	return strings.Join(bb, "\n\n")
+}
+
+// DB returns a `*pop.Connection` from the current
+// context `c.Value("tx")`. Returns `nil` if no
+// connection is found.
+func (d *DefaultContext) DB() *pop.Connection {
+	if c, ok := d.Value("tx").(*pop.Connection); ok {
+		return c
+	}
+	return nil
+}
+
+// Scope returns a `*pop.Query` if there is one in
+// the current context `c.Value("dbScope")`. If there is
+// no query found, then `DB()` is called, and if not `nil`
+// a new query is returned off that connection.
+func (d *DefaultContext) Scope() *pop.Query {
+	if q, ok := d.Value("dbScope").(*pop.Query); ok {
+		return q
+	}
+	if c := d.DB(); c != nil {
+		return c.Q()
+	}
+	return nil
 }
 
 var defaultUpgrader = websocket.Upgrader{

--- a/generators/resource/templates/actions/resource-json-xml.go.tmpl
+++ b/generators/resource/templates/actions/resource-json-xml.go.tmpl
@@ -28,14 +28,11 @@ type {{.opts.Name.Resource}}Resource struct{
 // List gets all {{.opts.Model.ModelPlural}}. This function is mapped to the path
 // GET /{{.opts.Name.URL}}
 func (v {{.opts.Name.Resource}}Resource) List(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   {{.opts.Model.VarCasePlural}} := &models.{{.opts.Model.ModelPlural}}{}
 
   // Paginate results. Params "page" and "per_page" control pagination.
   // Default values are "page=1" and "per_page=20".
-  q := tx.PaginateFromParams(c.Params())
+  q := c.Scope().PaginateFromParams(c.Params())
 
   // Retrieve all {{.opts.Model.ModelPlural}} from the DB
   if err := q.All({{.opts.Model.VarCasePlural}}); err != nil {
@@ -51,14 +48,11 @@ func (v {{.opts.Name.Resource}}Resource) List(c buffalo.Context) error {
 // Show gets the data for one {{.opts.Model.Model}}. This function is mapped to
 // the path GET /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}
 func (v {{.opts.Name.Resource}}Resource) Show(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
   // To find the {{.opts.Model.Model}} the parameter {{.opts.Model.UnderSingular}}_id is used.
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
 
@@ -82,7 +76,7 @@ func (v {{.opts.Name.Resource}}Resource) Create(c buffalo.Context) error {
   }
 
   // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
+  tx := c.DB()
 
   // Validate the data from the html form
   verrs, err := tx.ValidateAndCreate({{.opts.Model.VarCaseSingular}})
@@ -106,13 +100,10 @@ func (v {{.opts.Name.Resource}}Resource) Edit(c buffalo.Context) error {
 // Update changes a {{.opts.Model.Model}} in the DB. This function is mapped to
 // the path PUT /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}
 func (v {{.opts.Name.Resource}}Resource) Update(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
 
@@ -120,6 +111,9 @@ func (v {{.opts.Name.Resource}}Resource) Update(c buffalo.Context) error {
   if err := c.Bind({{.opts.Model.VarCaseSingular}}); err != nil {
     return errors.WithStack(err)
   }
+
+  // Get the DB connection from the context
+  tx := c.DB()
 
   verrs, err := tx.ValidateAndUpdate({{.opts.Model.VarCaseSingular}})
   if err != nil {
@@ -137,16 +131,16 @@ func (v {{.opts.Name.Resource}}Resource) Update(c buffalo.Context) error {
 // Destroy deletes a {{.opts.Model.Model}} from the DB. This function is mapped
 // to the path DELETE /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}
 func (v {{.opts.Name.Resource}}Resource) Destroy(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
   // To find the {{.opts.Model.Model}} the parameter {{.opts.Model.UnderSingular}}_id is used.
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
+
+  // Get the DB connection from the context
+  tx := c.Value("tx").(*pop.Connection)
 
   if err := tx.Destroy({{.opts.Model.VarCaseSingular}}); err != nil {
     return errors.WithStack(err)

--- a/generators/resource/templates/actions/resource-json-xml.go.tmpl
+++ b/generators/resource/templates/actions/resource-json-xml.go.tmpl
@@ -139,10 +139,7 @@ func (v {{.opts.Name.Resource}}Resource) Destroy(c buffalo.Context) error {
     return c.Error(404, err)
   }
 
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
-  if err := tx.Destroy({{.opts.Model.VarCaseSingular}}); err != nil {
+  if err := c.DB().Destroy({{.opts.Model.VarCaseSingular}}); err != nil {
     return errors.WithStack(err)
   }
 

--- a/generators/resource/templates/actions/resource-use_model.go.tmpl
+++ b/generators/resource/templates/actions/resource-use_model.go.tmpl
@@ -177,7 +177,7 @@ func (v {{.opts.Name.Resource}}Resource) Destroy(c buffalo.Context) error {
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
   // To find the {{.opts.Model.Model}} the parameter {{.opts.Model.UnderSingular}}_id is used.
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
 

--- a/generators/resource/templates/actions/resource-use_model.go.tmpl
+++ b/generators/resource/templates/actions/resource-use_model.go.tmpl
@@ -28,14 +28,11 @@ type {{.opts.Name.Resource}}Resource struct{
 // List gets all {{.opts.Model.ModelPlural}}. This function is mapped to the path
 // GET /{{.opts.Name.URL}}
 func (v {{.opts.Name.Resource}}Resource) List(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   {{.opts.Model.VarCasePlural}} := &models.{{.opts.Model.ModelPlural}}{}
 
   // Paginate results. Params "page" and "per_page" control pagination.
   // Default values are "page=1" and "per_page=20".
-  q := tx.PaginateFromParams(c.Params())
+  q := c.Scope().PaginateFromParams(c.Params())
 
   // Retrieve all {{.opts.Model.ModelPlural}} from the DB
   if err := q.All({{.opts.Model.VarCasePlural}}); err != nil {
@@ -54,14 +51,11 @@ func (v {{.opts.Name.Resource}}Resource) List(c buffalo.Context) error {
 // Show gets the data for one {{.opts.Model.Model}}. This function is mapped to
 // the path GET /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}
 func (v {{.opts.Name.Resource}}Resource) Show(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
   // To find the {{.opts.Model.Model}} the parameter {{.opts.Model.UnderSingular}}_id is used.
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
 
@@ -92,7 +86,7 @@ func (v {{.opts.Name.Resource}}Resource) Create(c buffalo.Context) error {
   }
 
   // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
+  tx := c.DB()
 
   // Validate the data from the html form
   verrs, err := tx.ValidateAndCreate({{.opts.Model.VarCaseSingular}})
@@ -122,13 +116,10 @@ func (v {{.opts.Name.Resource}}Resource) Create(c buffalo.Context) error {
 // Edit renders a edit form for a {{.opts.Model.Model}}. This function is
 // mapped to the path GET /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}/edit
 func (v {{.opts.Name.Resource}}Resource) Edit(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
 
@@ -140,13 +131,10 @@ func (v {{.opts.Name.Resource}}Resource) Edit(c buffalo.Context) error {
 // Update changes a {{.opts.Model.Model}} in the DB. This function is mapped to
 // the path PUT /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}
 func (v {{.opts.Name.Resource}}Resource) Update(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
-  if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
+  if err := c.Scope().Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
 
@@ -154,6 +142,9 @@ func (v {{.opts.Name.Resource}}Resource) Update(c buffalo.Context) error {
   if err := c.Bind({{.opts.Model.VarCaseSingular}}); err != nil {
     return errors.WithStack(err)
   }
+
+  // Get the DB connection from the context
+  tx := c.DB()
 
   verrs, err := tx.ValidateAndUpdate({{.opts.Model.VarCaseSingular}})
   if err != nil {
@@ -182,9 +173,6 @@ func (v {{.opts.Name.Resource}}Resource) Update(c buffalo.Context) error {
 // Destroy deletes a {{.opts.Model.Model}} from the DB. This function is mapped
 // to the path DELETE /{{.opts.Name.URL}}/{{"{"}}{{.opts.Model.UnderSingular}}_id}
 func (v {{.opts.Name.Resource}}Resource) Destroy(c buffalo.Context) error {
-  // Get the DB connection from the context
-  tx := c.Value("tx").(*pop.Connection)
-
   // Allocate an empty {{.opts.Model.Model}}
   {{.opts.Model.VarCaseSingular}} := &models.{{.opts.Model.Model}}{}
 
@@ -192,6 +180,9 @@ func (v {{.opts.Name.Resource}}Resource) Destroy(c buffalo.Context) error {
   if err := tx.Find({{.opts.Model.VarCaseSingular}}, c.Param("{{.opts.Model.UnderSingular}}_id")); err != nil {
     return c.Error(404, err)
   }
+
+  // Get the DB connection from the context
+  tx := c.DB()
 
   if err := tx.Destroy({{.opts.Model.VarCaseSingular}}); err != nil {
     return errors.WithStack(err)


### PR DESCRIPTION
The idea is that if I have a method on a Resource like this:

```go
func (v GroupsResource) Scope(c buffalo.Context) *pop.Query {
	cu := c.Value("current_user").(*models.User)
	tx := c.Value("tx").(*pop.Connection)
	return tx.BelongsToThrough(cu, "members")
}
```

When that Resource is mounted a new middleware would be added to that group which would execute that `Scope` function and put the results in the `Context`. 

The `Context` also would gain two new methods:

* `Scope()` - returns whatever the value of `dbScope` in the `Context` is. This could be generated using the above Resource method, or perhaps by the user themselves in a middleware.
* `DB()` - returns the `tx` in the `Context`, if it's there.

So, the question is, should we do this?