### PR TITLE
Fix Gitlab MySQL url on new generation

### DIFF
--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -51,7 +51,7 @@ func (a Generator) Run(root string, data makr.Data) error {
 			if a.DBType == "postgres" {
 				data["testDbUrl"] = "postgres://postgres:postgres@postgres:5432/" + a.Name.File() + "_test?sslmode=disable"
 			} else if a.DBType == "mysql" {
-				data["testDbUrl"] = "mysql://root:root@mysql:3306/" + a.Name.File() + "_test"
+				data["testDbUrl"] = "mysql://root:root@(mysql:3306)/" + a.Name.File() + "_test"
 			} else {
 				data["testDbUrl"] = ""
 			}


### PR DESCRIPTION
Eventually was able to discover an error message in Gitlab-CI that 'The URL is
not supported by MySQL driver.' Turns out the driver expects the hostname:port
to be enclosed in parenthesis.

Related to https://github.com/gobuffalo/buffalo/issues/575