### PR TITLE
no longer need extensions for templates in actions or partials for HTML, JS, and Markdown

### DIFF
--- a/render/html_test.go
+++ b/render/html_test.go
@@ -2,8 +2,8 @@ package render_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,7 +14,12 @@ import (
 func Test_HTML(t *testing.T) {
 	r := require.New(t)
 
-	tmpFile, err := ioutil.TempFile("", "test")
+	tmpDir := filepath.Join(os.TempDir(), "html_test")
+	err := os.MkdirAll(tmpDir, 0766)
+	r.NoError(err)
+	defer os.Remove(tmpDir)
+
+	tmpFile, err := os.Create(filepath.Join(tmpDir, "test.html"))
 	r.NoError(err)
 	defer os.Remove(tmpFile.Name())
 
@@ -37,7 +42,7 @@ func Test_HTML(t *testing.T) {
 	t.Run("with a layout", func(st *testing.T) {
 		r := require.New(st)
 
-		layout, err := ioutil.TempFile("", "test")
+		layout, err := os.Create(filepath.Join(tmpDir, "layout.html"))
 		r.NoError(err)
 		defer os.Remove(layout.Name())
 
@@ -61,7 +66,7 @@ func Test_HTML(t *testing.T) {
 
 		st.Run("overriding the HTMLLayout", func(sst *testing.T) {
 			r := require.New(sst)
-			nlayout, err := ioutil.TempFile("", "test-layout2")
+			nlayout, err := os.Create(filepath.Join(tmpDir, "layout2.html"))
 			r.NoError(err)
 			defer os.Remove(nlayout.Name())
 

--- a/render/js_test.go
+++ b/render/js_test.go
@@ -16,9 +16,13 @@ import (
 func Test_JavaScript(t *testing.T) {
 	r := require.New(t)
 
-	tmpFile, err := ioutil.TempFile("", "test")
+	tmpDir := filepath.Join(os.TempDir(), "markdown_test")
+	err := os.MkdirAll(tmpDir, 0766)
 	r.NoError(err)
-	defer os.Remove(tmpFile.Name())
+	defer os.Remove(tmpDir)
+
+	tmpFile, err := os.Create(filepath.Join(tmpDir, "test.js"))
+	r.NoError(err)
 
 	_, err = tmpFile.Write([]byte("<%= name %>"))
 	r.NoError(err)
@@ -39,9 +43,8 @@ func Test_JavaScript(t *testing.T) {
 	t.Run("with a layout", func(st *testing.T) {
 		r := require.New(st)
 
-		layout, err := ioutil.TempFile("", "test")
+		layout, err := os.Create(filepath.Join(tmpDir, "layout.js"))
 		r.NoError(err)
-		defer os.Remove(layout.Name())
 
 		_, err = layout.Write([]byte("<body><%= yield %></body>"))
 		r.NoError(err)
@@ -63,9 +66,8 @@ func Test_JavaScript(t *testing.T) {
 
 		st.Run("overriding the JavaScriptLayout", func(sst *testing.T) {
 			r := require.New(sst)
-			nlayout, err := ioutil.TempFile("", "test-layout2")
+			nlayout, err := os.Create(filepath.Join(tmpDir, "layout2.js"))
 			r.NoError(err)
-			defer os.Remove(nlayout.Name())
 
 			_, err = nlayout.Write([]byte("<html><%= yield %></html>"))
 			r.NoError(err)

--- a/render/markdown_test.go
+++ b/render/markdown_test.go
@@ -2,7 +2,6 @@ package render_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +46,7 @@ func Test_Markdown(t *testing.T) {
 	t.Run("with a layout", func(st *testing.T) {
 		r := require.New(st)
 
-		layout, err := ioutil.TempFile("", "test")
+		layout, err := os.Create(filepath.Join("", "test.html"))
 		r.NoError(err)
 		defer os.Remove(layout.Name())
 

--- a/render/template.go
+++ b/render/template.go
@@ -47,12 +47,24 @@ func (s templateRenderer) partial(name string, dd Data) (template.HTML, error) {
 }
 
 func (s templateRenderer) exec(name string, data Data) (template.HTML, error) {
+	ct := strings.ToLower(s.contentType)
+	data["contentType"] = ct
+
+	if filepath.Ext(name) == "" {
+		switch {
+		case strings.Contains(ct, "html"):
+			name += ".html"
+		case strings.Contains(ct, "javascript"):
+			name += ".js"
+		case strings.Contains(ct, "markdown"):
+			name += ".md"
+		}
+	}
+
 	source, err := s.TemplatesBox.MustBytes(name)
 	if err != nil {
 		return "", err
 	}
-
-	data["contentType"] = strings.ToLower(s.contentType)
 
 	helpers := map[string]interface{}{
 		"partial": s.partial,


### PR DESCRIPTION
With this change you no longer are required to add extensions if the template has the same content type as the template it's being called from, or the render engine calling it. This only works with HTML, JavaScript, and Markdown.

```erb
<body>
  <%= partial("nav") %>

  <div class="container" id="main">
    <%= partial("flash") %>
    <%= yield %>
  </div>

  <%= partial("footer") %>

</body>
```

```go
func HomeHandler(c buffalo.Context) error {
	return c.Render(200, r.HTML("index"))
}
```