### PR TITLE
Suggestion to provide more helpful error messages (say for port conflicts)

### DIFF
--- a/app.go
+++ b/app.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -107,10 +108,20 @@ func (a *App) Serve() error {
 func (a *App) Stop(err error) error {
 	a.cancel()
 	if err != nil && errors.Cause(err) != context.Canceled {
-		fmt.Println(err)
+		fmt.Println(errorWithHelp(err))
 		return err
 	}
 	return nil
+}
+
+//Try to augment an error with a useful help message
+func errorWithHelp(err error) string {
+	switch {
+	case strings.Contains(err.Error(), "address already in use"):
+		return fmt.Sprintf("%v \n%v", err.Error(), "Try using a different port by setting the PORT environment variable")
+
+	}
+	return err.Error()
 }
 
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I tried to start 2 go buffalo apps in dev mode today and received a "listen tcp 127.0.0.1:3000: bind: address already in use" error.

I couldn't quickly find how to over-ride the default port (had to go looking through the code) so though it might be helpful to future users if buffalo suggested how to resolve this type of error.

I'm assume there might be other error cases where a similar message would be useful.

I'm fully aware this will probably need to be refactored but thought I'd put through a pull request to explain my idea.

BTW: I also wondered about putting in a flag to override the default port, eg. buffalo dev -p <port number> this would then show in help which would also be a quick way for people to resolve this in future. 

Happy to work on this commandline flag option if you are interested?