### PR TITLE
Fix Issue #751 - unknown flag: --use-model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN buffalo build -static
 RUN buffalo g resource users name:text email:text
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/resource_model_migration.json
 
+RUN buffalo g resource admins --use-model users
+RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/resource_use_model.json
+
+RUN rm actions/admins_test.go
 RUN rm models/user_test.go
 RUN rm models/user.go
 RUN rm actions/users_test.go

--- a/buffalo/cmd/filetests/resource_use_model.json
+++ b/buffalo/cmd/filetests/resource_use_model.json
@@ -1,0 +1,19 @@
+[{
+    "path": "actions/admins.go",
+    "contains": [
+            "users := &models.Users{}"
+        ]
+    },
+    {
+    "path": "models/admin.go",
+    "absent": true
+},{
+    "path": "models/admin_test.go",
+    "absent": true
+},{
+    "path": "migrations/*_create_admins.up.fizz",
+    "absent": true
+},{
+    "path": "migrations/*_create_admins.down.fizz",
+    "absent": true
+}]

--- a/buffalo/cmd/generate/resource.go
+++ b/buffalo/cmd/generate/resource.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/gobuffalo/buffalo/generators/resource"
+	"github.com/gobuffalo/buffalo/meta"
 	"github.com/gobuffalo/makr"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,7 @@ import (
 var resourceOptions = struct {
 	SkipMigration bool
 	SkipModel     bool
+	ModelName     string
 	Name          string
 	MimeType      string
 }{}
@@ -31,6 +33,10 @@ var ResourceCmd = &cobra.Command{
 		o.MimeType = strings.ToUpper(resourceOptions.MimeType)
 		o.SkipModel = resourceOptions.SkipModel
 		o.SkipMigration = resourceOptions.SkipMigration
+		if resourceOptions.ModelName != "" {
+			o.UseModel = true
+			o.Model = meta.Name(resourceOptions.ModelName)
+		}
 
 		if err := o.Validate(); err != nil {
 			return err
@@ -43,8 +49,9 @@ var ResourceCmd = &cobra.Command{
 var resourceMN string
 
 func init() {
-	ResourceCmd.Flags().BoolVarP(&resourceOptions.SkipMigration, "skip-migration", "s", false, "sets resource generator not-to add model migration")
-	ResourceCmd.Flags().BoolVarP(&resourceOptions.SkipModel, "skip-model", "", false, "makes resource generator not to generate model nor migrations")
+	ResourceCmd.Flags().BoolVarP(&resourceOptions.SkipMigration, "skip-migration", "s", false, "tells resource generator not-to add model migration")
+	ResourceCmd.Flags().BoolVarP(&resourceOptions.SkipModel, "skip-model", "", false, "tells resource generator not to generate model nor migrations")
+	ResourceCmd.Flags().StringVarP(&resourceOptions.ModelName, "use-model", "", "", "tells resource generator to reference an existing model in generated code")
 	ResourceCmd.Flags().StringVarP(&resourceOptions.Name, "name", "n", "", "allows to define a different model name for the resource being generated.")
 	ResourceCmd.Flags().StringVarP(&resourceOptions.MimeType, "type", "", "html", "sets the resource type (html, json, xml)")
 }

--- a/generators/resource/generator.go
+++ b/generators/resource/generator.go
@@ -16,6 +16,7 @@ type Generator struct {
 	Model         meta.Name `json:"model"`
 	SkipMigration bool      `json:"skip_migration"`
 	SkipModel     bool      `json:"skip_model"`
+	UseModel      bool      `json:"use_model"`
 	MimeType      string    `json:"mime_type"`
 	FilesPath     string    `json:"files_path"`
 	ActionsPath   string    `json:"actions_path"`

--- a/generators/resource/resource.go
+++ b/generators/resource/resource.go
@@ -63,7 +63,7 @@ func (res Generator) Run(root string, data makr.Data) error {
 		},
 	})
 
-	if !res.SkipModel {
+	if !res.SkipModel && !res.UseModel {
 		g.Add(res.modelCommand())
 	}
 


### PR DESCRIPTION
Fix for #751 - unknown flag: --use-model
Re-implemented the --use-model logic so that if this string is set, the generator will still generate code using the specified model but won't try to re-create the model or migration.

Also made some minor updates to improve readability in help text in `buffalo g r -h`