### PR TITLE
Fix #784 Broken layout when using --skip-webpack

### DIFF
--- a/generators/newapp/templates/templates/_flash.html.tmpl
+++ b/generators/newapp/templates/templates/_flash.html.tmpl
@@ -1,3 +1,4 @@
+<%= if (len(flash) > 0) { %>
 <div class="row">
   <div class="col-md-12">
     <%= for (k, messages) in flash { %>
@@ -10,3 +11,4 @@
     <% } %>
   </div>
 </div>
+<% } %>

--- a/generators/newapp/templates/templates/application.html.tmpl
+++ b/generators/newapp/templates/templates/application.html.tmpl
@@ -1,7 +1,11 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
     <title>Buffalo - {{ .opts.Name.Title }}</title>
+  {{- if not .opts.WithWebpack }}
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  {{- end }}
     <%= stylesheetTag("application.css") %>
     <meta name="csrf-param" content="authenticity_token" />
     <meta name="csrf-token" content="<%= authenticity_token %>" />


### PR DESCRIPTION
* Include Bootstrap link when --skip-webpack is used.
* Add missing DOCTYPE.
* Add a condition to show flashes markup only when there are flashes.