### PR TITLE
Add UNIX domain socket binding support

### DIFF
--- a/cookies_test.go
+++ b/cookies_test.go
@@ -37,7 +37,7 @@ func TestCookies_Set(t *testing.T) {
 	c.Set("name", "Rob Pike", time.Hour*24)
 
 	h := res.Header().Get("Set-Cookie")
-	r.Equal("name=\"Rob Pike\"; Max-Age=86400", h)
+	r.Equal("name=Rob Pike; Max-Age=86400", h)
 }
 
 func TestCookies_SetWithExpirationTime(t *testing.T) {
@@ -50,7 +50,7 @@ func TestCookies_SetWithExpirationTime(t *testing.T) {
 	c.SetWithExpirationTime("name", "Rob Pike", e)
 
 	h := res.Header().Get("Set-Cookie")
-	r.Equal("name=\"Rob Pike\"; Expires=Sat, 29 Jul 2017 19:28:45 GMT", h)
+	r.Equal("name=Rob Pike; Expires=Sat, 29 Jul 2017 19:28:45 GMT", h)
 }
 
 func TestCookies_Delete(t *testing.T) {

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -37,7 +37,7 @@ func TestCookies_Set(t *testing.T) {
 	c.Set("name", "Rob Pike", time.Hour*24)
 
 	h := res.Header().Get("Set-Cookie")
-	r.Equal("name=Rob Pike; Max-Age=86400", h)
+	r.Equal("name=\"Rob Pike\"; Max-Age=86400", h)
 }
 
 func TestCookies_SetWithExpirationTime(t *testing.T) {
@@ -50,7 +50,7 @@ func TestCookies_SetWithExpirationTime(t *testing.T) {
 	c.SetWithExpirationTime("name", "Rob Pike", e)
 
 	h := res.Header().Get("Set-Cookie")
-	r.Equal("name=Rob Pike; Expires=Sat, 29 Jul 2017 19:28:45 GMT", h)
+	r.Equal("name=\"Rob Pike\"; Expires=Sat, 29 Jul 2017 19:28:45 GMT", h)
 }
 
 func TestCookies_Delete(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/gobuffalo/buffalo/worker"
@@ -75,7 +76,15 @@ func optionsWithDefaults(opts Options) Options {
 	if opts.Env == "development" {
 		addr = "127.0.0.1"
 	}
-	opts.Addr = defaults.String(opts.Addr, fmt.Sprintf("%s:%s", envy.Get("ADDR", addr), envy.Get("PORT", "3000")))
+	envAddr := envy.Get("ADDR", addr)
+
+	if strings.HasPrefix(envAddr, "unix:") {
+		// UNIX domain socket doesn't have a port
+		opts.Addr = envAddr
+	} else {
+		// TCP case
+		opts.Addr = defaults.String(opts.Addr, fmt.Sprintf("%s:%s", envAddr, envy.Get("PORT", "3000")))
+	}
 
 	if opts.PreWares == nil {
 		opts.PreWares = []PreWare{}


### PR DESCRIPTION
* Allow Buffalo to run on an UNIX socket (e.g. unix:/tmp/buffalo.sock)

To test the feature (not available on Windows):
```
$ ADDR=unix:/tmp/buffalo.sock buffalo dev
```

```
$ curl --unix-socket /tmp/buffalo.sock http://localhost/
```