### PR TITLE
Fix #782: avoid name collision with ISO lang code

### DIFF
--- a/middleware/i18n/i18n.go
+++ b/middleware/i18n/i18n.go
@@ -1,7 +1,9 @@
 package i18n
 
 import (
+	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 
 	"github.com/gobuffalo/buffalo"
@@ -43,7 +45,12 @@ func (t *Translator) Load() error {
 			log.Fatal(err)
 			return errors.WithStack(err)
 		}
-		return i18n.ParseTranslationFileBytes(path, b)
+
+		base := filepath.Base(path)
+		dir := filepath.Dir(path)
+
+		// Add a prefix to the loaded string, to avoid collision with an ISO lang code
+		return i18n.ParseTranslationFileBytes(fmt.Sprintf("%sbuff%s", dir, base), b)
 	})
 }
 

--- a/middleware/i18n/i18n_test.go
+++ b/middleware/i18n/i18n_test.go
@@ -43,6 +43,9 @@ func app() *buffalo.App {
 		c.Set("Users", usersList)
 		return c.Render(200, r.HTML("format.html"))
 	})
+	app.GET("/collision", func(c buffalo.Context) error {
+		return c.Render(200, r.HTML("collision.html"))
+	})
 	app.GET("/localized", func(c buffalo.Context) error {
 		return c.Render(200, r.HTML("localized_view.html"))
 	})
@@ -137,4 +140,12 @@ func Test_i18n_Localized_View(t *testing.T) {
 	req.Headers["Accept-Language"] = "en-UK,en-US;q=0.5"
 	res = req.Get()
 	r.Equal("Default", strings.TrimSpace(res.Body.String()))
+}
+
+func Test_i18n_collision(t *testing.T) {
+	r := require.New(t)
+
+	w := willie.New(app())
+	res := w.Request("/collision").Get()
+	r.Equal("Collision OK", strings.TrimSpace(res.Body.String()))
 }

--- a/middleware/i18n/locales/ms_batchs.en-us.yaml
+++ b/middleware/i18n/locales/ms_batchs.en-us.yaml
@@ -1,0 +1,2 @@
+- id: iso-code-collision
+  translation: Collision OK

--- a/middleware/i18n/templates/collision.html
+++ b/middleware/i18n/templates/collision.html
@@ -1,0 +1,1 @@
+<%= t("iso-code-collision") %>


### PR DESCRIPTION
* Add a "buff" prefix on i18n files loading to avoid name collision with ISO lang code