### PR TITLE
Set a default addr for any environment apart from development 

### DIFF
--- a/options.go
+++ b/options.go
@@ -72,7 +72,7 @@ func optionsWithDefaults(opts Options) Options {
 	opts.Env = defaults.String(opts.Env, envy.Get("GO_ENV", "development"))
 	opts.LogLevel = defaults.String(opts.LogLevel, "debug")
 	opts.Name = defaults.String(opts.Name, "/")
-	addr := ""
+	addr := "0.0.0.0"
 	if opts.Env == "development" {
 		addr = "127.0.0.1"
 	}


### PR DESCRIPTION
When `GO_ENV` was not `development` the address was not being set. Set the default address to `0.0.0.0` when no environment is set making the application having a smart default for when deploying to Heroku or a docker environment. 