### PR TITLE
On windows error Error: fork/exec go\bin\buffalo-goth.exe: The parame…

### DIFF
--- a/buffalo/cmd/plugins.go
+++ b/buffalo/cmd/plugins.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 
 	"github.com/gobuffalo/buffalo/plugins"
@@ -51,7 +52,9 @@ func decorate(name string, cmd *cobra.Command) {
 
 					ax = append(ax, args...)
 					ex := exec.Command(c.Binary, ax...)
-					ex.Env = append(envy.Environ(), "BUFFALO_PLUGIN=1")
+					if runtime.GOOS != "windows" {
+						ex.Env = append(envy.Environ(), "BUFFALO_PLUGIN=1")
+					}
 					ex.Stdin = os.Stdin
 					ex.Stdout = os.Stdout
 					ex.Stderr = os.Stderr


### PR DESCRIPTION
…ter is incorrect. fixes https://github.com/gobuffalo/buffalo-goth/issues/5