### PR TITLE
"Fix" Issue #841

### DIFF
--- a/buffalo/cmd/build.go
+++ b/buffalo/cmd/build.go
@@ -77,5 +77,5 @@ func init() {
 	xbuildCmd.Flags().StringVar(&buildOptions.LDFlags, "ldflags", "", "set any ldflags to be passed to the go build")
 	xbuildCmd.Flags().BoolVarP(&buildOptions.Debug, "debug", "d", false, "print debugging information")
 	xbuildCmd.Flags().BoolVarP(&buildOptions.Compress, "compress", "c", true, "compress static files in the binary")
-	xbuildCmd.Flags().StringVarP(&buildOptions.Environment, "environment", "e", "development", "set the environment for the binary (defaults to 'development')")
+	xbuildCmd.Flags().StringVarP(&buildOptions.Environment, "environment", "", "development", "set the environment for the binary")
 }

--- a/buffalo/cmd/build.go
+++ b/buffalo/cmd/build.go
@@ -77,5 +77,5 @@ func init() {
 	xbuildCmd.Flags().StringVar(&buildOptions.LDFlags, "ldflags", "", "set any ldflags to be passed to the go build")
 	xbuildCmd.Flags().BoolVarP(&buildOptions.Debug, "debug", "d", false, "print debugging information")
 	xbuildCmd.Flags().BoolVarP(&buildOptions.Compress, "compress", "c", true, "compress static files in the binary")
-
+	xbuildCmd.Flags().StringVarP(&buildOptions.Environment, "environment", "e", "development", "set the environment for the binary (defaults to 'development')")
 }

--- a/buffalo/cmd/build/bin.go
+++ b/buffalo/cmd/build/bin.go
@@ -64,6 +64,6 @@ func (b *Builder) buildBin() error {
 	}
 
 	buildArgs = append(buildArgs, "-ldflags", strings.Join(flags, " "))
-
+	
 	return b.exec(envy.Get("GO_BIN", "go"), buildArgs...)
 }

--- a/buffalo/cmd/build/exec.go
+++ b/buffalo/cmd/build/exec.go
@@ -22,7 +22,9 @@ func (debugWriter) Write(data []byte) (int, error) {
 func (b *Builder) exec(name string, args ...string) error {
 	cmd := exec.CommandContext(b.ctx, name, args...)
 	logrus.Debugf("running %s", strings.Join(cmd.Args, " "))
+	
 	//cmd.Env = envy.Environ()
+	
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = debugWriter(0)

--- a/buffalo/cmd/build/options.go
+++ b/buffalo/cmd/build/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	Static        bool     `json:"static"`
 	Debug         bool     `json:"debug"`
 	Compress      bool     `json:"compress"`
+	Environment   string   `json:"environment"`
 }
 
 func (o Options) String() string {

--- a/buffalo/cmd/build/templates/main.go.tmpl
+++ b/buffalo/cmd/build/templates/main.go.tmpl
@@ -9,6 +9,7 @@ import (
   _ "<%= opts.PackagePkg %>/a"
   _ "<%= opts.ActionsPkg %>"
   <%= if (opts.WithPop) { %>
+  "github.com/gobuffalo/envy"
   "github.com/gobuffalo/packr"
   "github.com/markbates/pop"
   "<%= opts.ModelsPkg %>"
@@ -20,6 +21,10 @@ import (
 
 var BuildVersion = "unknown"
 var BuildTime = "unknown"
+
+func init() {
+  envy.Set("GO_ENV", "<%= opts.Environment%>")
+}
 
 func main() {
   args := os.Args


### PR DESCRIPTION
I want to make sure if this should be the proper way to set the development environment for the build, in order to procceed with testing & possible mistake corrections.

A new environment flag is registered and defaulted to "development".
Then, on **bin.go**, its passed to envy (not persisted to the underlying environment), in order to procceed to **exec.go** without changing function signatures.

The value is retrieved from envy and appended in the Env slice of **exec.Cmd** so it can be used instead of the default one on the actual command execution step.

https://github.com/gobuffalo/buffalo/issues/841