### PR TITLE
updated node-sass package to fix issue: #875

### DIFF
--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -22,7 +22,7 @@
     "font-awesome": "~4.7.0",
     "jquery": "~3.2.1",
     "jquery-ujs": "~1.2.2",
-    "node-sass": "~4.5.3",
+    "node-sass": "~4.7.2",
     "npm-install-webpack-plugin": "4.0.4",
     "path": "~0.12.7",
     "sass-loader": "~6.0.5",


### PR DESCRIPTION
Updating to node-sass 4.7.2 fixes platform not supported error with Mac OSX 10.12.6 (16G1212)