### PR TITLE
Removed beta tag from bootstrap 4

### DIFF
--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -9,7 +9,7 @@
     "babel-loader": "~7.0.0",
     "babel-preset-env": "~1.5.2",
     {{ if eq .opts.Bootstrap 4 -}}
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "4.0.0",
     {{ else -}}
     "bootstrap-sass": "~3.3.7",
     {{ end -}}


### PR DESCRIPTION
Bootstrap 4 is out of beta now, so no need for the beta tag.