### PR TITLE
Allow for testing a single package

### DIFF
--- a/buffalo/cmd/test.go
+++ b/buffalo/cmd/test.go
@@ -100,7 +100,7 @@ func testRunner(args []string) error {
 	}
 
 	if !runFlag {
-		pkgs, err := testPackages()
+		pkgs, err := testPackages(args)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -115,7 +115,7 @@ func mFlagRunner(args []string) error {
 	pwd, _ := os.Getwd()
 	defer os.Chdir(pwd)
 
-	pkgs, err := testPackages()
+	pkgs, err := testPackages(args)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -139,7 +139,14 @@ func mFlagRunner(args []string) error {
 	return nil
 }
 
-func testPackages() ([]string, error) {
+func testPackages(givenArgs []string) ([]string, error) {
+	// If there are args, then assume these are the packages to test.
+	//
+	// Instead of always returning all packages from 'go list ./...', just
+	// return the given packages in this case
+	if len(givenArgs) > 0 {
+		return givenArgs, nil
+	}
 	args := []string{}
 	out, err := exec.Command(envy.Get("GO_BIN", "go"), "list", "./...").Output()
 	if err != nil {
@@ -159,7 +166,6 @@ func newTestCmd(args []string) *exec.Cmd {
 	if _, err := exec.LookPath("gotest"); err == nil {
 		cmd = exec.Command("gotest", "-p", "1")
 	}
-	cmd.Args = append(cmd.Args, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
I can't find any tests for the commands, so I ran it manually against the toodo app:

```console
aaschles-> ../buffalo/cli test ./actions
dropped database toodo_testing
created database toodo_testing
loaded schema for toodo_testing
INFO[0000] go test -p 1 ./actions
```

Fixes https://github.com/gobuffalo/buffalo/issues/907

cc/ @markbates @paganotoni 