### PR TITLE
Less ugly production error page

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -220,11 +220,75 @@ var devErrorTmpl = `
 </html>
 `
 var prodErrorTmpl = `
-<h1>We're Sorry!</h1>
-<p>
-It looks like something went wrong! Don't worry, we are aware of the problem and are looking into it.
-</p>
-<p>
-Sorry if this has caused you any problems. Please check back again later.
-</p>
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+	background: #ECECEC;
+	padding-top: 25px;
+}
+
+.card {
+	box-sizing: border-box;
+	width: 440px;
+	min-width: 270px;
+	margin: 0 auto;
+	padding: 10px 25px;
+	border-radius:  4px;
+	box-shadow: #ddd -2px 3px 10px;
+	padding-bottom: 20px;
+	background: #FFFFFF;
+	box-shadow: 0 2px 4px 0 rgba(185,185,185,0.28);
+	border-radius: 5px;
+}
+
+.card p {
+	width: 350px;
+	margin: 15px auto;
+}
+
+body {
+	font-family: helvetica neue, helvetica, sans-serif;
+	color: #333;
+}
+
+h1 {
+	text-align: center;
+	font-size: 22px;
+}
+
+hr {
+	border: 0.5px solid #D72727;
+  width: 180px;
+}
+
+p.powered {
+	text-align: center;
+	font-family: HelveticaNeue-Light;
+	font-size: 12px;
+	color: #333333;
+}
+
+@media (max-width: 600px) {
+  .card {
+		width: 100%;
+		display: block;
+	}
+}
+</style>
+</head>
+<body>
+<div class="container">
+	<div class="card">
+		<h1>We're Sorry!</h1>
+		<hr>
+		<p>It looks like something went wrong! Don't worry, we are aware of the problem and are looking into it.</p>
+		<p>Sorry if this has caused you any problems. Please check back again later.</p>
+	</div>
+
+	<p class="powered">powered by <a href="https://gobuffalo.io">gobuffalo.io</a></p>
+</div>
+</body>
+</html>
 `

--- a/errors.go
+++ b/errors.go
@@ -253,7 +253,7 @@ body {
 }
 
 .card p {
-	width: 320px;
+	max-width: 320px;
 	margin: 15px auto;
 }
 
@@ -326,7 +326,7 @@ body {
 }
 
 .card p {
-	width: 350px;
+	max-width: 320px;
 	margin: 15px auto;
 }
 

--- a/errors.go
+++ b/errors.go
@@ -244,17 +244,16 @@ body {
 	width: 440px;
 	min-width: 270px;
 	margin: 0 auto;
-	padding: 10px 25px;
+	padding: 10px 25px 35px 10px;
 	border-radius:  4px;
 	box-shadow: #ddd -2px 3px 10px;
-	padding-bottom: 20px;
 	background: #FFFFFF;
 	box-shadow: 0 2px 4px 0 rgba(185,185,185,0.28);
 	border-radius: 5px;
 }
 
 .card p {
-	width: 350px;
+	width: 320px;
 	margin: 15px auto;
 }
 
@@ -318,10 +317,9 @@ body {
 	width: 440px;
 	min-width: 270px;
 	margin: 0 auto;
-	padding: 10px 25px;
+	padding: 10px 25px 35px 10px;
 	border-radius:  4px;
 	box-shadow: #ddd -2px 3px 10px;
-	padding-bottom: 20px;
 	background: #FFFFFF;
 	box-shadow: 0 2px 4px 0 rgba(185,185,185,0.28);
 	border-radius: 5px;

--- a/errors.go
+++ b/errors.go
@@ -72,15 +72,25 @@ func (a *App) PanicHandler(next Handler) Handler {
 	}
 }
 
+func productionErrorResponseFor(status int) []byte {
+	if status == http.StatusNotFound {
+		return []byte(prodNotFoundTmpl)
+	}
+
+	return []byte(prodErrorTmpl)
+}
+
 func defaultErrorHandler(status int, err error, c Context) error {
 	env := c.Value("env")
+
 	c.Logger().Error(err)
+	c.Response().WriteHeader(status)
+
 	if env != nil && env.(string) == "production" {
-		c.Response().WriteHeader(status)
-		c.Response().Write([]byte(prodErrorTmpl))
+		responseBody := productionErrorResponseFor(status)
+		c.Response().Write(responseBody)
 		return nil
 	}
-	c.Response().WriteHeader(status)
 
 	msg := fmt.Sprintf("%+v", err)
 	ct := httpx.ContentType(c.Request())
@@ -285,6 +295,79 @@ p.powered {
 		<hr>
 		<p>It looks like something went wrong! Don't worry, we are aware of the problem and are looking into it.</p>
 		<p>Sorry if this has caused you any problems. Please check back again later.</p>
+	</div>
+
+	<p class="powered">powered by <a href="https://gobuffalo.io">gobuffalo.io</a></p>
+</div>
+</body>
+</html>
+`
+
+var prodNotFoundTmpl = `
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+	background: #ECECEC;
+	padding-top: 25px;
+}
+
+.card {
+	box-sizing: border-box;
+	width: 440px;
+	min-width: 270px;
+	margin: 0 auto;
+	padding: 10px 25px;
+	border-radius:  4px;
+	box-shadow: #ddd -2px 3px 10px;
+	padding-bottom: 20px;
+	background: #FFFFFF;
+	box-shadow: 0 2px 4px 0 rgba(185,185,185,0.28);
+	border-radius: 5px;
+}
+
+.card p {
+	width: 350px;
+	margin: 15px auto;
+}
+
+body {
+	font-family: helvetica neue, helvetica, sans-serif;
+	color: #333;
+}
+
+h1 {
+	text-align: center;
+	font-size: 22px;
+}
+
+hr {
+	border: 0.5px solid #1272E2;
+  width: 180px;
+}
+
+p.powered {
+	text-align: center;
+	font-family: HelveticaNeue-Light;
+	font-size: 12px;
+	color: #333333;
+}
+
+@media (max-width: 600px) {
+  .card {
+		width: 100%;
+		display: block;
+	}
+}
+</style>
+</head>
+<body>
+<div class="container">
+	<div class="card">
+		<h1>Not Found</h1>
+		<hr>
+		<p>The page you’re looking for does not exist, you may have mistyped the address or the page may have been moved.</p>
 	</div>
 
 	<p class="powered">powered by <a href="https://gobuffalo.io">gobuffalo.io</a></p>


### PR DESCRIPTION
Given what we discussed in #930 I decided to start with this simple design for the error page, it adds some styling to it so we can have a better-looking error page for production:

![error-page](https://user-images.githubusercontent.com/645522/37033365-ca56f714-2113-11e8-837b-d2c1d8a8c9b7.png)

(nothing fancy for now)

@markbates @stanislas-m sorry for the delay with this one, I think we can iterate from this first version, LMK if you guys want to change copy or any style you don't like.