### PR TITLE
Check for dep and goimports before go getting.

### DIFF
--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -32,9 +32,14 @@ func (a Generator) Run(root string, data makr.Data) error {
 		os.RemoveAll(a.Root)
 	}
 
-	g.Add(makr.NewCommand(makr.GoGet("golang.org/x/tools/cmd/goimports", "-u")))
+	if _, err := exec.LookPath("goimports"); err != nil {
+		g.Add(makr.NewCommand(makr.GoGet("golang.org/x/tools/cmd/goimports", "-u")))
+	}
+
 	if a.WithDep {
-		g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep/cmd/dep", "-u")))
+		if _, err := exec.LookPath("dep"); err != nil {
+			g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep/cmd/dep", "-u")))
+		}
 	}
 
 	files, err := generators.FindByBox(packr.NewBox("../newapp/templates"))


### PR DESCRIPTION
Conditionally `go get`ing `dep` and `goimports`. I noticed that even though I had them installed via package manger on Arch, Buffalo was `go get`ing them. Might be annoying for those that like a clean `GOPATH`.