### PR TITLE
Added http:// to server address in log to make it clickable

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,7 +37,7 @@ type App struct {
 // interrupt and kill signals and will attempt to stop the application
 // gracefully. This will also start the Worker process, unless WorkerOff is enabled.
 func (a *App) Serve() error {
-	logrus.Infof("Starting application at %s", a.Options.Addr)
+	logrus.Infof("Starting application at http://%s", a.Options.Addr)
 	server := http.Server{
 		Handler: a,
 	}

--- a/app.go
+++ b/app.go
@@ -37,7 +37,7 @@ type App struct {
 // interrupt and kill signals and will attempt to stop the application
 // gracefully. This will also start the Worker process, unless WorkerOff is enabled.
 func (a *App) Serve() error {
-	logrus.Infof("Starting application at http://%s", a.Options.Addr)
+	logrus.Infof("Starting application at %s", a.Options.Host)
 	server := http.Server{
 		Handler: a,
 	}


### PR DESCRIPTION
Enhancement: After starting a server, it would be nice to be able to click the server address in the console to open a browser. Adding http:// before the address in the current log output will make it clickable in some IDE's, and easier to copy & paste in others.

This is an edit to a line of logs, so it could be considered a content or documentation change.  I'm not sure there is an easily accessible way to write unit tests.