### PR TITLE
Add test for template partial rendering with a local variable.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.9.0
+FROM golang:latest
 
 RUN go version
 

--- a/render/template_test.go
+++ b/render/template_test.go
@@ -79,7 +79,7 @@ func Test_Template_Partial(t *testing.T) {
 }
 
 
-func Test_Template_Partial_With_Gloabl_Context(t *testing.T) {
+func Test_Template_Partial_Recursive_With_Global_And_Local_Context(t *testing.T) {
 	r := require.New(t)
 
 	tPath, err := ioutil.TempDir("", "")
@@ -89,13 +89,19 @@ func Test_Template_Partial_With_Gloabl_Context(t *testing.T) {
 	partFile, err := os.Create(filepath.Join(tPath, "_foo.html"))
 	r.NoError(err)
 
-	_, err = partFile.Write([]byte("Foo > <%= name %>"))
+	_, err = partFile.Write([]byte(`Foo > <%= name %> > <%= partial("bar.html", {name: "Alex"}) %>`))
+	r.NoError(err)
+
+	partFile2, err := os.Create(filepath.Join(tPath, "_bar.html"))
+	r.NoError(err)
+
+	_, err = partFile2.Write([]byte("Bar > <%= name %> > <%= other %>"))
 	r.NoError(err)
 
 	tmpFile, err := os.Create(filepath.Join(tPath, "index.html"))
 	r.NoError(err)
 
-	_, err = tmpFile.Write([]byte(`<%= partial("foo.html", {other: "value"}) %>`))
+	_, err = tmpFile.Write([]byte(`<%= partial("foo.html", {other: "Other"}) %>`))
 	r.NoError(err)
 
 	type ji func(string, ...string) render.Renderer
@@ -109,7 +115,7 @@ func Test_Template_Partial_With_Gloabl_Context(t *testing.T) {
 	bb := &bytes.Buffer{}
 	err = re.Render(bb, render.Data{"name": "Mark"})
 	r.NoError(err)
-	r.Equal("Foo > Mark", strings.TrimSpace(bb.String()))
+	r.Equal("Foo > Mark > Bar > Alex > Other", strings.TrimSpace(bb.String()))
 }
 
 func Test_Template_Partial_WithoutExtension(t *testing.T) {

--- a/render/template_test.go
+++ b/render/template_test.go
@@ -78,6 +78,40 @@ func Test_Template_Partial(t *testing.T) {
 	r.Equal("Foo > Mark", strings.TrimSpace(bb.String()))
 }
 
+
+func Test_Template_Partial_With_Gloabl_Context(t *testing.T) {
+	r := require.New(t)
+
+	tPath, err := ioutil.TempDir("", "")
+	r.NoError(err)
+	defer os.Remove(tPath)
+
+	partFile, err := os.Create(filepath.Join(tPath, "_foo.html"))
+	r.NoError(err)
+
+	_, err = partFile.Write([]byte("Foo > <%= name %>"))
+	r.NoError(err)
+
+	tmpFile, err := os.Create(filepath.Join(tPath, "index.html"))
+	r.NoError(err)
+
+	_, err = tmpFile.Write([]byte(`<%= partial("foo.html", {other: "value"}) %>`))
+	r.NoError(err)
+
+	type ji func(string, ...string) render.Renderer
+
+	j := render.New(render.Options{
+		TemplatesBox: packr.NewBox(tPath),
+	}).Template
+
+	re := j("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+	bb := &bytes.Buffer{}
+	err = re.Render(bb, render.Data{"name": "Mark"})
+	r.NoError(err)
+	r.Equal("Foo > Mark", strings.TrimSpace(bb.String()))
+}
+
 func Test_Template_Partial_WithoutExtension(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
Hi Mark,

After reading the documentation on partial rendering (https://gobuffalo.io/en/docs/partials#local-context) I expected local and global variables to be merged. This doesn't seem to happen at present. That may be the desired behaviour?

This adds a failing test case. It could be combined with the existing test case, depending on your preferred approach.

I've created a candidate fix in `plush/compiler.go` for which I'll submit an MR for review.

Best wishes,

Alex