### PR TITLE
split out a few things from the generated action.App() implementation. 

### DIFF
--- a/generators/newapp/templates/actions/app.go.tmpl
+++ b/generators/newapp/templates/actions/app.go.tmpl
@@ -47,10 +47,7 @@ func App() *buffalo.App {
       SessionName: "_{{.opts.Name.File}}_session",
     })
     // Automatically redirect to SSL
-    app.Use(ssl.ForceSSL(secure.Options{
-      SSLRedirect:     ENV == "production",
-      SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"},
-    }))
+    app.Use(forceSSL())
 
     {{ if .opts.AsAPI -}}
     // Set the request content type to JSON
@@ -76,11 +73,7 @@ func App() *buffalo.App {
 
     {{ if .opts.AsWeb -}}
     // Setup and use translations:
-    var err error
-    if T, err = i18n.New(packr.NewBox("../locales"), "en-US"); err != nil {
-      app.Stop(err)
-    }
-    app.Use(T.Middleware())
+    app.Use(translations())
     {{ end }}
 
     app.GET("/", HomeHandler)
@@ -91,4 +84,28 @@ func App() *buffalo.App {
   }
 
   return app
+}
+
+{{ if .opts.AsWeb -}}
+// translations will load locale files, set up the translator `actions.T`,
+// and will return a middleware to use to load the correct locale for each
+// request.
+// for more information: https://gobuffalo.io/en/docs/localization
+func translations() buffalo.MiddlewareFunc {
+  var err error
+  if T, err = i18n.New(packr.NewBox("../locales"), "en-US"); err != nil {
+    app.Stop(err)
+  }
+  return T.Middleware()
+}
+{{ end }}
+
+// forceSSL will return a middleware that will redirect an incoming request
+// if it is not HTTPS. "http://example.com" => "https://example.com".
+// for more information: https://github.com/unrolled/secure/
+func forceSSL() buffalo.MiddlewareFunc {
+  return ssl.ForceSSL(secure.Options{
+    SSLRedirect:     ENV == "production",
+    SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"},
+  })
 }

--- a/generators/newapp/templates/actions/app.go.tmpl
+++ b/generators/newapp/templates/actions/app.go.tmpl
@@ -102,6 +102,8 @@ func translations() buffalo.MiddlewareFunc {
 
 // forceSSL will return a middleware that will redirect an incoming request
 // if it is not HTTPS. "http://example.com" => "https://example.com".
+// This middleware does **not** enable SSL. for your application. To do that
+// we recommend using a proxy: https://gobuffalo.io/en/docs/proxy
 // for more information: https://github.com/unrolled/secure/
 func forceSSL() buffalo.MiddlewareFunc {
   return ssl.ForceSSL(secure.Options{

--- a/generators/newapp/templates/main.go.tmpl
+++ b/generators/newapp/templates/main.go.tmpl
@@ -6,9 +6,33 @@ import (
   "{{ .opts.ActionsPkg }}"
 )
 
+// main is the starting point to your Buffalo application.
+// you can feel free and add to this `main` method, change
+// what it does, etc...
+// All we ask is that, at some point, you make sure to
+// call `app.Serve()`, unless you don't want to start your
+// application that is. :)
 func main() {
   app := actions.App()
   if err := app.Serve(); err != nil {
     log.Fatal(err)
   }
 }
+
+/*
+# Notes about `main.go`
+
+## SSL Support
+
+We recommend placing your application behind a proxy, such as
+Apache or Nginx and letting them do the SSL heaving lifting
+for you. https://gobuffalo.io/en/docs/proxy
+
+## Buffalo Build
+
+When `buffalo build` is run to compile your binary this `main`
+function will be at the heart of that binary. It is expected
+that your `main` function will start your application using
+the `app.Serve()` method.
+
+*/


### PR DESCRIPTION
Hopefully this will help with a bit more in-line documentation, as well, as showing a pattern for keeping that method tame when it starts getting big.