### PR TITLE
Fix #886: ensure generated CSRF is not overriden

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -65,12 +65,13 @@ var New = func(next buffalo.Handler) buffalo.Handler {
 		}
 
 		var realToken []byte
+		var err error
 		rawRealToken := c.Session().Get(tokenKey)
 
 		if rawRealToken == nil || len(rawRealToken.([]byte)) != tokenLength {
 			// If the token is missing, or the length if the token is wrong,
 			// generate a new token.
-			realToken, err := generateRandomBytes(tokenLength)
+			realToken, err = generateRandomBytes(tokenLength)
 			if err != nil {
 				return err
 			}
@@ -171,8 +172,9 @@ func compareTokens(a, b []byte) bool {
 // one-time-pad used to mask it.
 func xorToken(a, b []byte) []byte {
 	n := len(a)
-	if len(b) < n {
-		n = len(b)
+	bn := len(b)
+	if bn < n {
+		n = bn
 	}
 
 	res := make([]byte, n)


### PR DESCRIPTION
* In the case realToken was regenerated, a scoped redefinition was overriding
    the token to nil.