### PR TITLE
Adding clean-obsolete-chunks which will clean up on recompile

### DIFF
--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -3,25 +3,28 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "repository": "github.com/gobuffalo/buffalo",
   "dependencies": {
-    "babel-cli": "~6.26.0",
-    "babel-core": "~6.26.0",
-    "babel-loader": "~7.1.2",
-    "babel-preset-env": "~1.5.2",
     {{ if eq .opts.Bootstrap 4 -}}
     "bootstrap": "4.0.0",
     {{ else -}}
     "bootstrap-sass": "~3.3.7",
     {{ end -}}
-    "clean-webpack-plugin": "~0.1.19",
+    "font-awesome": "~4.7.0",
+    "jquery": "~3.2.1",
+    "jquery-ujs": "~1.2.2"
+  },
+  "devDependencies": {
+    "babel-cli": "~6.26.0",
+    "babel-core": "~6.26.0",
+    "babel-loader": "~7.1.2",
+    "babel-preset-env": "~1.5.2",
+    "webpack-clean-obsolete-chunks": "^0.4.0",
     "copy-webpack-plugin": "~4.5.1",
     "css-loader": "~0.28.11",
     "expose-loader": "~0.7.5",
     "file-loader": "~1.1.11",
-    "font-awesome": "~4.7.0",
     "gopherjs-loader": "^0.0.1",
-    "jquery": "~3.2.1",
-    "jquery-ujs": "~1.2.2",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass": "~4.8.3",
     "npm-install-webpack-plugin": "4.0.5",

--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -3,7 +3,7 @@ const Glob = require("glob");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const ManifestPlugin = require("webpack-manifest-plugin");
-const CleanWebpackPlugin = require("clean-webpack-plugin");
+const CleanObsoleteChunks = require('webpack-clean-obsolete-chunks');
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 const configurator = {
@@ -38,7 +38,7 @@ const configurator = {
 
   plugins() {
     var plugins = [
-      new CleanWebpackPlugin(["public/assets"], {verbose: false,}),
+      new CleanObsoleteChunks(),
       new Webpack.ProvidePlugin({$: "jquery",jQuery: "jquery"}),
       new MiniCssExtractPlugin({filename: "[name][contenthash].css"}),
       new CopyWebpackPlugin([{from: "./assets",to: ""}], {copyUnmodified: true,ignore: ["css/**", "js/**"] }),


### PR DESCRIPTION
This PR makes our webpack config clean obsolete chunks so instead of just cleaning all the `public/assets` folder this will remove only obsolete chunks, this will cause 2 great outcomes:

- We no longer will have trash chunks after recompiling
- Styles will load fast after we've already compiled (p.e application restart doesn't need to do the compilation from scratch).

