### PR TITLE
fix resource name handling bug

### DIFF
--- a/router.go
+++ b/router.go
@@ -131,7 +131,7 @@ func (a *App) Resource(p string, r Resource) *App {
 	rt := rv.Type()
 	rname := fmt.Sprintf("%s.%s", rt.PkgPath(), rt.Name()) + ".%s"
 
-	name := strings.Replace(rt.Name(), "Resource", "", 1)
+	name := strings.TrimSuffix(rt.Name(), "Resource")
 	paramName := inflect.Name(name).ParamID()
 
 	type paramKeyable interface {

--- a/router_test.go
+++ b/router_test.go
@@ -342,11 +342,18 @@ func Test_App_NamedRoutes(t *testing.T) {
 		*BaseResource
 	}
 
+	type ResourcesResource struct {
+		*BaseResource
+	}
+
 	r := require.New(t)
 	a := New(Options{})
 
 	var carsResource Resource
 	carsResource = CarsResource{&BaseResource{}}
+
+	var resourcesResource Resource
+	resourcesResource = ResourcesResource{&BaseResource{}}
 
 	rr := render.New(render.Options{
 		HTMLLayout:   "application.html",
@@ -367,6 +374,8 @@ func Test_App_NamedRoutes(t *testing.T) {
 			9. <%= rootPath({"some":"variable","other": 12}) %>
 			10. <%= rootPath() %>
 			11. <%= rootPath({"special/":"12=ss"}) %>
+			12. <%= resourcePath({resource_id: 1}) %>
+			13. <%= editResourcePath({resource_id: 1}) %>
 		`))
 	}
 
@@ -375,6 +384,7 @@ func Test_App_NamedRoutes(t *testing.T) {
 	a.GET("/users/{user_id}", sampleHandler)
 	a.GET("/peeps", sampleHandler).Name("myPeeps")
 	a.Resource("/car", carsResource)
+	a.Resource("/resources", resourcesResource)
 
 	w := willie.New(a)
 	res := w.Request("/").Get()
@@ -390,6 +400,8 @@ func Test_App_NamedRoutes(t *testing.T) {
 	r.Contains(res.Body.String(), "9. /?other=12&some=variable")
 	r.Contains(res.Body.String(), "10. /")
 	r.Contains(res.Body.String(), "11. /?special%2F=12%3Dss")
+	r.Contains(res.Body.String(), "12. /resources/1")
+	r.Contains(res.Body.String(), "13. /resources/1/edit")
 }
 
 func Test_App_NamedRoutes_MissingParameter(t *testing.T) {


### PR DESCRIPTION
Hi, while I generate resource named `resources`, I found a bug on name detection routine `Resource()` function.

If I generate my resource with "resource" (`buffalo generate resource resources`), the structure name of generated resource is `ResourcesResource` and `strings.Replace()` on `Resource()` of `router.go` replaces first `Resource` and remaining `sResource` is used as resource name.

I replaced `Replace()` with `TrimSuffix()` and I think it is fit for the logic too.
I also added some test cases for this.