### PR TITLE
allow for redirects in actions using a path helper

### DIFF
--- a/default_context.go
+++ b/default_context.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"runtime"
 	"sort"
 	"strings"
@@ -184,9 +185,35 @@ func (d *DefaultContext) Websocket() (*websocket.Conn, error) {
 	return defaultUpgrader.Upgrade(d.Response(), d.Request(), nil)
 }
 
+var mapType = reflect.ValueOf(map[string]interface{}{}).Type()
+
 // Redirect a request with the given status to the given URL.
 func (d *DefaultContext) Redirect(status int, url string, args ...interface{}) error {
 	d.Flash().persist(d.Session())
+
+	if strings.HasSuffix(url, "Path") {
+		if len(args) > 1 {
+			return errors.WithStack(errors.Errorf("you must pass only a map[string]interface{} to a route path: %T", args))
+		}
+		var m map[string]interface{}
+		if len(args) == 1 {
+			rv := reflect.Indirect(reflect.ValueOf(args[0]))
+			if !rv.Type().ConvertibleTo(mapType) {
+				return errors.WithStack(errors.Errorf("you must pass only a map[string]interface{} to a route path: %T", args))
+			}
+			m = rv.Convert(mapType).Interface().(map[string]interface{})
+		}
+		h, ok := d.Value(url).(RouteHelperFunc)
+		if !ok {
+			return errors.WithStack(errors.Errorf("could not find a route helper named %s", url))
+		}
+		url, err := h(m)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		http.Redirect(d.Response(), d.Request(), string(url), status)
+		return nil
+	}
 
 	if len(args) > 0 {
 		url = fmt.Sprintf(url, args...)

--- a/default_context.go
+++ b/default_context.go
@@ -191,7 +191,7 @@ var mapType = reflect.ValueOf(map[string]interface{}{}).Type()
 func (d *DefaultContext) Redirect(status int, url string, args ...interface{}) error {
 	d.Flash().persist(d.Session())
 
-	if strings.HasSuffix(url, "Path") {
+	if strings.HasSuffix(url, "Path()") {
 		if len(args) > 1 {
 			return errors.WithStack(errors.Errorf("you must pass only a map[string]interface{} to a route path: %T", args))
 		}
@@ -203,7 +203,7 @@ func (d *DefaultContext) Redirect(status int, url string, args ...interface{}) e
 			}
 			m = rv.Convert(mapType).Interface().(map[string]interface{})
 		}
-		h, ok := d.Value(url).(RouteHelperFunc)
+		h, ok := d.Value(strings.TrimSuffix(url, "()")).(RouteHelperFunc)
 		if !ok {
 			return errors.WithStack(errors.Errorf("could not find a route helper named %s", url))
 		}

--- a/default_context_test.go
+++ b/default_context_test.go
@@ -65,10 +65,10 @@ func Test_DefaultContext_Redirect_Helper(t *testing.T) {
 			return c.Render(200, render.String(c.Param("bar")))
 		})
 		a.GET("/", func(c Context) error {
-			return c.Redirect(302, "fooPath", tt.I)
+			return c.Redirect(302, "fooPath()", tt.I)
 		})
 		a.GET("/nomap", func(c Context) error {
-			return c.Redirect(302, "rootPath")
+			return c.Redirect(302, "rootPath()")
 		})
 
 		w := willie.New(a)


### PR DESCRIPTION
```go
return c.Redirect(302, "widgetPath()", render.Data{"widget_id": widget.ID})
// or
return c.Redirect(302, "widgetPath()", map[string]interface{}{"widget_id": widget.ID})
```

Replaces PR https://github.com/gobuffalo/buffalo/pull/622