### PR TITLE
Allow the buffalo binary to use the version vendored with dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,4 +140,3 @@ RUN buffalo new app -f --api
 WORKDIR $GOPATH/src/app
 RUN buffalo version > output.txt 2>&1
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/version-no-dep.json
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,18 @@ RUN buffalo version
 
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install
+
 RUN go get -v -u github.com/markbates/filetest
+
 RUN go get -v -u github.com/gobuffalo/makr
-RUN go get -v -u github.com/markbates/grift
-RUN go get -v -u github.com/markbates/inflect
-RUN go get -v -u github.com/markbates/refresh
 RUN go get -v -u github.com/gobuffalo/tags
 RUN go get -v -u github.com/gobuffalo/pop
 RUN go get -v -u github.com/mattn/go-sqlite3
+
+RUN go get -v -u github.com/markbates/grift
+RUN go get -v -u github.com/markbates/inflect
+RUN go get -v -u github.com/markbates/refresh
+RUN go get -v -u github.com/markbates/willie
 
 ENV BP=$GOPATH/src/github.com/gobuffalo/buffalo
 
@@ -22,7 +26,6 @@ WORKDIR $BP
 ADD . .
 
 RUN go get -v -t ./...
-
 RUN go install -v -tags sqlite ./buffalo
 
 RUN go test -tags sqlite -race ./...
@@ -123,3 +126,18 @@ RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/g
 RUN rm -rf bin
 RUN buffalo build -k -e
 RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/no_assets_build.json
+
+# Vendored buffalo version.
+WORKDIR $GOPATH/src
+RUN buffalo new app -f --api --with-dep
+WORKDIR $GOPATH/src/app
+RUN buffalo version > output.txt 2>&1
+RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/version-dep.json
+
+# Non-Vendored buffalo version.
+WORKDIR $GOPATH/src
+RUN buffalo new app -f --api
+WORKDIR $GOPATH/src/app
+RUN buffalo version > output.txt 2>&1
+RUN filetest -c $GOPATH/src/github.com/gobuffalo/buffalo/buffalo/cmd/filetests/version-no-dep.json
+

--- a/buffalo/cmd/build/assets.go
+++ b/buffalo/cmd/build/assets.go
@@ -23,6 +23,8 @@ func (b *Builder) buildAssets() error {
 
 	if !b.Options.WithAssets {
 		p.IgnoredBoxes = append(p.IgnoredBoxes, "../public/assets")
+	} else {
+		p.IgnoredFolders = p.IgnoredFolders[1:]
 	}
 
 	if b.ExtractAssets && b.Options.WithAssets {

--- a/buffalo/cmd/build/builder.go
+++ b/buffalo/cmd/build/builder.go
@@ -47,6 +47,12 @@ func (b *Builder) Run() error {
 	defer b.Cleanup()
 	logrus.Debug(b.Options)
 
+	if b.Debug {
+		builder.DebugLog = func(m string, a ...interface{}) {
+			logrus.Debugf(m, a...)
+		}
+	}
+
 	for _, s := range b.steps {
 		err := s()
 		if err != nil {

--- a/buffalo/cmd/build/templates/main.go.tmpl
+++ b/buffalo/cmd/build/templates/main.go.tmpl
@@ -6,6 +6,7 @@ import (
   "os"
 
   "github.com/markbates/grift/grift"
+  "github.com/gobuffalo/buffalo/buffalo/cmd"
   _ "<%= opts.PackagePkg %>/a"
   _ "<%= opts.ActionsPkg %>"
   <%= if (opts.WithPop) { %>
@@ -47,7 +48,7 @@ func main() {
       log.Fatal(err)
     }
   default:
-    originalMain()
+    cmd.Execute()
   }
 }
 

--- a/buffalo/cmd/filetests/version-dep.json
+++ b/buffalo/cmd/filetests/version-dep.json
@@ -1,6 +1,6 @@
 [{
   "path": "output.txt",
   "contains": [
-    "msg=\"Buffalo version is: v\n"
+    "msg=\"Buffalo version is: v"
   ]
 }]

--- a/buffalo/cmd/filetests/version-dep.json
+++ b/buffalo/cmd/filetests/version-dep.json
@@ -1,0 +1,6 @@
+[{
+  "path": "output.txt",
+  "contains": [
+    "msg=\"Buffalo version is: v\n"
+  ]
+}]

--- a/buffalo/cmd/filetests/version-no-dep.json
+++ b/buffalo/cmd/filetests/version-no-dep.json
@@ -1,0 +1,9 @@
+[{
+  "path": "output.txt",
+  "contains": [
+    "msg=\"Buffalo version is: development"
+  ],
+  "!contains": [
+    "msg=\"Buffalo version is: v"
+  ]
+}]

--- a/buffalo/cmd/info.go
+++ b/buffalo/cmd/info.go
@@ -71,6 +71,13 @@ func execIfExists(infoCmd infoCommand) error {
 	bb := os.Stdout
 	bb.WriteString(infoCmd.InfoLabel)
 
+	if infoCmd.Name == "dep" {
+		if _, err := os.Stat("Gopkg.toml"); err != nil {
+			bb.WriteString("could not find a Gopkg.toml file\n")
+			return nil
+		}
+	}
+
 	if _, err := exec.LookPath(infoCmd.PathName); err != nil {
 		bb.WriteString(fmt.Sprintf("%s Not Found\n", infoCmd.Name))
 		return nil

--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -70,7 +70,10 @@ var newCmd = &cobra.Command{
 			app.WithWebpack = false
 		}
 
-		if err := app.Run(app.Root, makr.Data{}); err != nil {
+		data := makr.Data{
+			"version": Version,
+		}
+		if err := app.Run(app.Root, data); err != nil {
 			return errors.WithStack(err)
 		}
 

--- a/buffalo/main.go
+++ b/buffalo/main.go
@@ -2,159 +2,17 @@ package main
 
 import (
 	"log"
-	"os"
-	"os/exec"
-	"path/filepath"
 
 	"github.com/gobuffalo/buffalo/buffalo/cmd"
-	"github.com/gobuffalo/buffalo/meta"
-	"github.com/gobuffalo/plush"
-	"github.com/pkg/errors"
+	"github.com/gobuffalo/buffalo/internal/vbuffalo"
 )
 
 func main() {
-	if exists(".buffalo.dev.yml") {
-		vBuffalo()
-		return
-	}
-	cmd.Execute()
-}
-
-var app meta.App
-
-// lol! it's "vBuffalo"!
-func vBuffalo() {
-	app = meta.New(".")
-	// not using dep or there isn't a vendor folder
-	if !app.WithDep || !exists("vendor") {
+	err := vbuffalo.Execute(func() error {
 		cmd.Execute()
-		return
-	}
-	if err := execute(); err != nil {
+		return nil
+	})
+	if err != nil {
 		log.Fatal(err)
 	}
 }
-
-const cmdPkg = "github.com/gobuffalo/buffalo/buffalo/cmd"
-
-var pwd, _ = os.Getwd()
-var exePath = filepath.Join(pwd, ".grifter", "main.go")
-var vBin = filepath.Join(pwd, "bin", "vbuffalo")
-
-func execute() (err error) {
-	dir := filepath.Dir(exePath)
-	err = os.MkdirAll(dir, 0755)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(dir); err != nil {
-			log.Println(err)
-		}
-	}()
-
-	if err := depEnsure(); err != nil {
-		return errors.WithStack(err)
-	}
-
-	if err = os.Symlink(filepath.Join(pwd, "vendor"), filepath.Join(filepath.Dir(exePath), "vendor")); err != nil {
-		return errors.WithStack(err)
-	}
-
-	if err = writeMain(); err != nil {
-		return errors.WithStack(err)
-	}
-
-	err = cd(filepath.Dir(exePath), func() error {
-		args := []string{"build", "-v"}
-		if app.WithSQLite {
-			args = append(args, "--tags", "sqlite")
-		}
-		args = append(args, "-o", vBin)
-		cmd := exec.Command("go", args...)
-		return run(cmd)
-	})
-
-	cmd := exec.Command(vBin, os.Args[1:]...)
-	return run(cmd)
-}
-
-func depEnsure() error {
-	// toml := filepath.Join(pwd, "Gopkg.toml")
-	// b, err := ioutil.ReadFile(toml)
-	// if err != nil {
-	// 	return errors.WithStack(err)
-	// }
-	return nil
-	// if bytes.Contains(b, []byte("github.com/gobuffalo/buffalo/...")) {
-	// 	return nil
-	// }
-	//
-	// f, err := os.Create(toml)
-	// if err != nil {
-	// 	return errors.WithStack(err)
-	// }
-	// f.WriteString("required = [\"github.com/gobuffalo/buffalo/...\"]\n")
-	// f.Write(b)
-	// if err := f.Close(); err != nil {
-	// 	return errors.WithStack(err)
-	// }
-	//
-	// return run(exec.Command("dep", "ensure", "-v"))
-}
-
-func cd(dir string, fn func() error) error {
-	defer os.Chdir(pwd)
-	os.Chdir(dir)
-	return fn()
-}
-
-func run(cmd *exec.Cmd) error {
-	// fmt.Println(strings.Join(cmd.Args, " "))
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func writeMain() error {
-	f, err := os.Create(exePath)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer f.Close()
-	s, err := plush.Render(mainTemplate, plush.NewContextWith(map[string]interface{}{
-		"app":    app,
-		"cmdPkg": cmdPkg,
-	}))
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	_, err = f.WriteString(s)
-	return err
-}
-
-func exists(f string) bool {
-	_, err := os.Stat(f)
-	return err == nil
-}
-
-const mainTemplate = `package main
-
-import (
-	"fmt"
-	"<%= cmdPkg %>"
-)
-
-func main() {
-	fmt.Println(cmd.Version)
-	cmd.Execute()
-}
-`
-
-const prune = `  [[prune.project]]
-    name = "github.com/gobuffalo/buffalo"
-    go-tests = true
-    non-go = false
-    unused-packages = false
-`

--- a/buffalo/main.go
+++ b/buffalo/main.go
@@ -1,7 +1,160 @@
 package main
 
-import "github.com/gobuffalo/buffalo/buffalo/cmd"
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gobuffalo/buffalo/buffalo/cmd"
+	"github.com/gobuffalo/buffalo/meta"
+	"github.com/gobuffalo/plush"
+	"github.com/pkg/errors"
+)
 
 func main() {
+	if exists(".buffalo.dev.yml") {
+		vBuffalo()
+		return
+	}
 	cmd.Execute()
 }
+
+var app meta.App
+
+// lol! it's "vBuffalo"!
+func vBuffalo() {
+	app = meta.New(".")
+	// not using dep or there isn't a vendor folder
+	if !app.WithDep || !exists("vendor") {
+		cmd.Execute()
+		return
+	}
+	if err := execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+const cmdPkg = "github.com/gobuffalo/buffalo/buffalo/cmd"
+
+var pwd, _ = os.Getwd()
+var exePath = filepath.Join(pwd, ".grifter", "main.go")
+var vBin = filepath.Join(pwd, "bin", "vbuffalo")
+
+func execute() (err error) {
+	dir := filepath.Dir(exePath)
+	err = os.MkdirAll(dir, 0755)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() {
+		if err = os.RemoveAll(dir); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	if err := depEnsure(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err = os.Symlink(filepath.Join(pwd, "vendor"), filepath.Join(filepath.Dir(exePath), "vendor")); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err = writeMain(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = cd(filepath.Dir(exePath), func() error {
+		args := []string{"build", "-v"}
+		if app.WithSQLite {
+			args = append(args, "--tags", "sqlite")
+		}
+		args = append(args, "-o", vBin)
+		cmd := exec.Command("go", args...)
+		return run(cmd)
+	})
+
+	cmd := exec.Command(vBin, os.Args[1:]...)
+	return run(cmd)
+}
+
+func depEnsure() error {
+	// toml := filepath.Join(pwd, "Gopkg.toml")
+	// b, err := ioutil.ReadFile(toml)
+	// if err != nil {
+	// 	return errors.WithStack(err)
+	// }
+	return nil
+	// if bytes.Contains(b, []byte("github.com/gobuffalo/buffalo/...")) {
+	// 	return nil
+	// }
+	//
+	// f, err := os.Create(toml)
+	// if err != nil {
+	// 	return errors.WithStack(err)
+	// }
+	// f.WriteString("required = [\"github.com/gobuffalo/buffalo/...\"]\n")
+	// f.Write(b)
+	// if err := f.Close(); err != nil {
+	// 	return errors.WithStack(err)
+	// }
+	//
+	// return run(exec.Command("dep", "ensure", "-v"))
+}
+
+func cd(dir string, fn func() error) error {
+	defer os.Chdir(pwd)
+	os.Chdir(dir)
+	return fn()
+}
+
+func run(cmd *exec.Cmd) error {
+	// fmt.Println(strings.Join(cmd.Args, " "))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func writeMain() error {
+	f, err := os.Create(exePath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+	s, err := plush.Render(mainTemplate, plush.NewContextWith(map[string]interface{}{
+		"app":    app,
+		"cmdPkg": cmdPkg,
+	}))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = f.WriteString(s)
+	return err
+}
+
+func exists(f string) bool {
+	_, err := os.Stat(f)
+	return err == nil
+}
+
+const mainTemplate = `package main
+
+import (
+	"fmt"
+	"<%= cmdPkg %>"
+)
+
+func main() {
+	fmt.Println(cmd.Version)
+	cmd.Execute()
+}
+`
+
+const prune = `  [[prune.project]]
+    name = "github.com/gobuffalo/buffalo"
+    go-tests = true
+    non-go = false
+    unused-packages = false
+`

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -37,6 +37,7 @@ func (a Generator) Run(root string, data makr.Data) error {
 	}
 
 	if a.WithDep {
+		g.Add(makr.NewFile("Gopkg.toml", gopkgToml))
 		if _, err := exec.LookPath("dep"); err != nil {
 			g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep/cmd/dep", "-u")))
 		}
@@ -199,7 +200,7 @@ func (a Generator) goGet() *exec.Cmd {
 	os.Chdir(a.Root)
 	if a.WithDep {
 		if _, err := exec.LookPath("dep"); err == nil {
-			return exec.Command("dep", "init")
+			return exec.Command("dep", "ensure", "-v")
 		}
 	}
 	appArgs := []string{"get", "-t"}
@@ -360,4 +361,13 @@ public/assets/
 .vscode/
 .grifter/
 .env
+`
+
+const gopkgToml = `
+# require the cmd package so we can use vBuffalo
+required = ["github.com/gobuffalo/buffalo/buffalo/cmd"]
+
+[prune]
+  go-tests = true
+  unused-packages = true
 `

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -364,6 +364,7 @@ public/assets/
 .env
 `
 
+// GopkgTomlTmpl is the default dep Gopkg.toml
 const GopkgTomlTmpl = `
 {{ if .addPrune }}
 [prune]

--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -37,7 +37,8 @@ func (a Generator) Run(root string, data makr.Data) error {
 	}
 
 	if a.WithDep {
-		g.Add(makr.NewFile("Gopkg.toml", gopkgToml))
+		data["addPrune"] = true
+		g.Add(makr.NewFile("Gopkg.toml", GopkgTomlTmpl))
 		if _, err := exec.LookPath("dep"); err != nil {
 			g.Add(makr.NewCommand(makr.GoGet("github.com/golang/dep/cmd/dep", "-u")))
 		}
@@ -363,11 +364,22 @@ public/assets/
 .env
 `
 
-const gopkgToml = `
-# require the cmd package so we can use vBuffalo
-required = ["github.com/gobuffalo/buffalo/buffalo/cmd"]
-
+const GopkgTomlTmpl = `
+{{ if .addPrune }}
 [prune]
   go-tests = true
   unused-packages = true
+{{ end }}
+
+  # DO NOT DELETE
+  [[prune.project]] # buffalo
+    name = "github.com/gobuffalo/buffalo"
+    unused-packages = false
+
+{{ if .opts.WithPop }}
+  # DO NOT DELETE
+  [[prune.project]] # pop
+    name = "github.com/gobuffalo/pop"
+    unused-packages = false
+{{ end }}
 `

--- a/internal/vbuffalo/build.go
+++ b/internal/vbuffalo/build.go
@@ -1,0 +1,40 @@
+package vbuffalo
+
+import (
+	"os"
+
+	"github.com/gobuffalo/buffalo/buffalo/cmd"
+	"github.com/gobuffalo/plush"
+	"github.com/pkg/errors"
+)
+
+func writeMain() error {
+	f, err := os.Create(mainPath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+	s, err := plush.Render(mainTemplate, plush.NewContextWith(map[string]interface{}{
+		"app":     app,
+		"cmdPkg":  cmdPkg,
+		"version": cmd.Version,
+	}))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = f.WriteString(s)
+	return err
+}
+
+const mainTemplate = `package main
+
+import (
+	"fmt"
+	"<%= cmdPkg %>"
+)
+
+func main() {
+	fmt.Printf("%s [<%= version %>]\n\n", cmd.Version)
+	cmd.Execute()
+}
+`

--- a/internal/vbuffalo/dep.go
+++ b/internal/vbuffalo/dep.go
@@ -7,7 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/alecthomas/template"
+	"html/template"
+
 	"github.com/gobuffalo/buffalo/generators/newapp"
 	"github.com/pkg/errors"
 )

--- a/internal/vbuffalo/dep.go
+++ b/internal/vbuffalo/dep.go
@@ -1,0 +1,59 @@
+package vbuffalo
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/alecthomas/template"
+	"github.com/gobuffalo/buffalo/generators/newapp"
+	"github.com/pkg/errors"
+)
+
+func depEnsure() error {
+	toml := filepath.Join(pwd, "Gopkg.toml")
+	b, err := ioutil.ReadFile(toml)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	addPrune := !bytes.Contains(b, []byte("[prune]"))
+
+	make := func() error {
+		f, err := os.Create(toml)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer f.Close()
+		f.Write(b)
+
+		t, err := template.New("toml template").Parse(newapp.GopkgTomlTmpl)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		err = t.Execute(f, map[string]interface{}{
+			"opts":     app,
+			"addPrune": addPrune,
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return run(exec.Command("dep", "ensure", "-v"))
+	}
+
+	if addPrune {
+		if err := make(); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	if !bytes.Contains(b, []byte("[[prune.project]] # buffalo")) {
+		if err := make(); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}

--- a/internal/vbuffalo/executable.go
+++ b/internal/vbuffalo/executable.go
@@ -1,3 +1,0 @@
-package vbuffalo
-
-type Executeable func() error

--- a/internal/vbuffalo/executable.go
+++ b/internal/vbuffalo/executable.go
@@ -1,0 +1,3 @@
+package vbuffalo
+
+type Executeable func() error

--- a/internal/vbuffalo/vbuffalo.go
+++ b/internal/vbuffalo/vbuffalo.go
@@ -1,0 +1,78 @@
+package vbuffalo
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gobuffalo/buffalo/meta"
+	"github.com/pkg/errors"
+)
+
+const cmdPkg = "github.com/gobuffalo/buffalo/buffalo/cmd"
+
+var pwd, _ = os.Getwd()
+var mainPath = filepath.Join(pwd, ".grifter", "main.go")
+var binPath = filepath.Join(pwd, "bin", "vbuffalo")
+var app meta.App
+
+func Execute(ex Executeable) error {
+	if !exists(".buffalo.dev.yml") {
+		return ex()
+	}
+	app = meta.New(".")
+	// not using dep or there isn't a vendor folder
+	if !app.WithDep || !exists("vendor") {
+		return ex()
+	}
+	return execute()
+}
+
+func execute() error {
+	dir := filepath.Dir(mainPath)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := depEnsure(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err = writeMain(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = cd(filepath.Dir(mainPath), func() error {
+		args := []string{"build", "-v"}
+		if app.WithSQLite {
+			args = append(args, "--tags", "sqlite")
+		}
+		args = append(args, "-o", binPath)
+		cmd := exec.Command("go", args...)
+		return run(cmd)
+	})
+
+	cmd := exec.Command(binPath, os.Args[1:]...)
+	return run(cmd)
+}
+
+func cd(dir string, fn func() error) error {
+	defer os.Chdir(pwd)
+	os.Chdir(dir)
+	return fn()
+}
+
+func run(cmd *exec.Cmd) error {
+	// fmt.Println(strings.Join(cmd.Args, " "))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func exists(f string) bool {
+	_, err := os.Stat(f)
+	return err == nil
+}

--- a/internal/vbuffalo/vbuffalo.go
+++ b/internal/vbuffalo/vbuffalo.go
@@ -62,6 +62,9 @@ func execute() error {
 		cmd := exec.Command("go", args...)
 		return run(cmd)
 	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
 	cmd := exec.Command(binPath, os.Args[1:]...)
 	return run(cmd)

--- a/internal/vbuffalo/vbuffalo.go
+++ b/internal/vbuffalo/vbuffalo.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/gobuffalo/buffalo/meta"
 	"github.com/pkg/errors"
@@ -15,6 +16,12 @@ var pwd, _ = os.Getwd()
 var mainPath = filepath.Join(pwd, ".grifter", "main.go")
 var binPath = filepath.Join(pwd, "bin", "vbuffalo")
 var app meta.App
+
+func init() {
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+}
 
 // Execute using vbuffalo. If this doesn't meet the vbuffalo
 // requirements then it should use the passed in function instead.

--- a/internal/vbuffalo/vbuffalo.go
+++ b/internal/vbuffalo/vbuffalo.go
@@ -16,7 +16,9 @@ var mainPath = filepath.Join(pwd, ".grifter", "main.go")
 var binPath = filepath.Join(pwd, "bin", "vbuffalo")
 var app meta.App
 
-func Execute(ex Executeable) error {
+// Execute using vbuffalo. If this doesn't meet the vbuffalo
+// requirements then it should use the passed in function instead.
+func Execute(ex func() error) error {
 	if !exists(".buffalo.dev.yml") {
 		return ex()
 	}

--- a/meta/app.go
+++ b/meta/app.go
@@ -1,7 +1,9 @@
 package meta
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -24,6 +26,7 @@ type App struct {
 	GriftsPkg   string       `json:"grifts_path"`
 	VCS         string       `json:"vcs"`
 	WithPop     bool         `json:"with_pop"`
+	WithSQLite  bool         `json:"with_sqlite"`
 	WithDep     bool         `json:"with_dep"`
 	WithWebpack bool         `json:"with_webpack"`
 	WithYarn    bool         `json:"with_yarn"`
@@ -78,9 +81,12 @@ func New(root string) App {
 	if runtime.GOOS == "windows" {
 		app.Bin += ".exe"
 	}
-
-	if _, err := os.Stat(filepath.Join(root, "database.yml")); err == nil {
+	db := filepath.Join(root, "database.yml")
+	if _, err := os.Stat(db); err == nil {
 		app.WithPop = true
+		if b, err := ioutil.ReadFile(db); err == nil {
+			app.WithSQLite = bytes.Contains(bytes.ToLower(b), []byte("sqlite"))
+		}
 	}
 	if _, err := os.Stat(filepath.Join(root, "Gopkg.toml")); err == nil {
 		app.WithDep = true


### PR DESCRIPTION
If the following conditions then `vbuffalo` will attempt take over:

* The app **MUST** be using dep
* The `vendor` directory **MUST** exist

If those conditions then `vbuffalo` behaves in a similar fashion to `grift`. It will first create a new `.grifter/main.go` and use that to build a new binary, `bin/vbuffalo` that has been compiled using the vendored version of Buffalo.

Another requirement is this section in `Gopkg.toml`

```toml
[prune]
  go-tests = true
  unused-packages = true

  # DO NOT DELETE
  [[prune.project]] # buffalo
    name = "github.com/gobuffalo/buffalo"
    unused-packages = false

  # DO NOT DELETE
  [[prune.project]] # pop
    name = "github.com/gobuffalo/pop"
    unused-packages = false
```

For new applications the appropriate toml will be generated. For existing applications we will add the missing `prune` sections to their `Gopkg.toml` file if they don't already have them.