### PR TITLE
moves to use bootstrap 4.1.1 to avoid a text-hide warning 

### DIFF
--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -8,7 +8,7 @@
     {{ if eq .opts.Bootstrap 3 -}}
     "bootstrap-sass": "~3.3.7",
     {{ else -}}
-    "bootstrap": "4.1.0",
+    "bootstrap": "4.1.1",
     {{ end -}}
     "font-awesome": "~4.7.0",
     "jquery": "~3.2.1",


### PR DESCRIPTION
Latest bootstrap releases removes a warning when compiling with the text-hide mixin, I've seen that warning in our development version since we move to use bootstrap 4.1.0 as default.

This PR moves buffalo to use 4.1.1 instead of 4.1.0.