### PR TITLE
moves to use bootstrap 4.1.1 to avoid a text-hide warning 

### DIFF
--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -8,7 +8,7 @@
     {{ if eq .opts.Bootstrap 3 -}}
     "bootstrap-sass": "~3.3.7",
     {{ else -}}
-    "bootstrap": "4.1.0",
+    "bootstrap": "4.1.1",
     {{ end -}}
     "font-awesome": "~4.7.0",
     "jquery": "~3.2.1",


### PR DESCRIPTION
Trying to fix git base problem in #1054 from @paganotoni.