### PR TITLE
Allowing to skip schema load

### DIFF
--- a/buffalo/cmd/test.go
+++ b/buffalo/cmd/test.go
@@ -22,9 +22,12 @@ import (
 const vendorPattern = "/vendor/"
 
 var vendorRegex = regexp.MustCompile(vendorPattern)
+var skipSchemaLoad = false
 
 func init() {
 	decorate("test", testCmd)
+	testCmd.Flags().BoolVarP(&buildOptions.ExtractAssets, "skip-schema-load", "s", false, "skips loading the schema and instead runs migrations before running tests")
+
 	RootCmd.AddCommand(testCmd)
 }
 
@@ -48,6 +51,20 @@ var testCmd = &cobra.Command{
 			err = test.Dialect.CreateDB()
 			if err != nil {
 				return errors.WithStack(err)
+			}
+
+			if skipSchemaLoad {
+				fm, err := pop.NewFileMigrator("./migrations", test)
+
+				if err != nil {
+					return err
+				}
+
+				if err := fm.Up(); err != nil {
+					return err
+				}
+
+				return testRunner(args)
 			}
 
 			if schema := findSchema(); schema != nil {

--- a/buffalo/cmd/test.go
+++ b/buffalo/cmd/test.go
@@ -26,7 +26,7 @@ var skipSchemaLoad = false
 
 func init() {
 	decorate("test", testCmd)
-	testCmd.Flags().BoolVarP(&buildOptions.ExtractAssets, "skip-schema-load", "s", false, "skips loading the schema and instead runs migrations before running tests")
+	testCmd.Flags().BoolVarP(&skipSchemaLoad, "skip-schema-load", "s", false, "skips loading the schema and instead runs migrations before running tests")
 
 	RootCmd.AddCommand(testCmd)
 }

--- a/buffalo/cmd/test.go
+++ b/buffalo/cmd/test.go
@@ -22,11 +22,11 @@ import (
 const vendorPattern = "/vendor/"
 
 var vendorRegex = regexp.MustCompile(vendorPattern)
-var skipSchemaLoad = false
+var forceMigrations = false
 
 func init() {
 	decorate("test", testCmd)
-	testCmd.Flags().BoolVarP(&skipSchemaLoad, "skip-schema-load", "s", false, "skips loading the schema and instead runs migrations before running tests")
+	testCmd.Flags().BoolVarP(&forceMigrations, "force-migrations", "m", false, "skips loading the schema and instead runs migrations before running tests")
 
 	RootCmd.AddCommand(testCmd)
 }
@@ -53,7 +53,7 @@ var testCmd = &cobra.Command{
 				return errors.WithStack(err)
 			}
 
-			if skipSchemaLoad {
+			if forceMigrations {
 				fm, err := pop.NewFileMigrator("./migrations", test)
 
 				if err != nil {


### PR DESCRIPTION
In some situations, the database user configured in the database connection is not the owner of the plpgsql extension, and Postgres ends up saying when we try to load the schema file.

```
Error: unable to load schema for application_test: pq: must be owner of extension plpgsql
```

This PR allows to skip schema load and go straight to migrations.