### PR TITLE
Fix test runner cmd

### DIFF
--- a/buffalo/cmd/test.go
+++ b/buffalo/cmd/test.go
@@ -214,8 +214,7 @@ func testPackages(givenArgs []string) ([]string, error) {
 func newTestCmd(args []string) *exec.Cmd {
 	cargs := []string{"test", "-p", "1"}
 	app := meta.New(".")
-	tf := "-tags " + app.BuildTags("development").String()
-	cargs = append(cargs, tf)
+	cargs = append(cargs, "-tags", app.BuildTags("development").String())
 	cargs = append(cargs, args...)
 	cmd := exec.Command(envy.Get("GO_BIN", "go"), cargs...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
The tags string was being concatenated... needed to be separate parts.