### PR TITLE
LooseSlash

### DIFF
--- a/app.go
+++ b/app.go
@@ -146,7 +146,7 @@ func New(opts Options) *App {
 			404: defaultErrorHandler,
 			500: defaultErrorHandler,
 		},
-		router:   mux.NewRouter().StrictSlash(!opts.LooseSlash),
+		router:   mux.NewRouter().StrictSlash(opts.LooseSlash),
 		moot:     &sync.Mutex{},
 		routes:   RouteList{},
 		children: []*App{},


### PR DESCRIPTION
Since when you pass `true` to gorilla/mux.StrictSlash it will interpret the route as a `LooseSlash` and when you pass `false` it's `strict` just passing `LooseSlash` will work. 
> StrictSlash in mux isn't so strict  ¯\＿(ツ)＿/¯

EDIT: Fixes #955 