### PR TITLE
fixes a regress bootstrap version

### DIFF
--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -152,7 +152,7 @@ func init() {
 	newCmd.Flags().String("docker", "multi", "specify the type of Docker file to generate [none, multi, standard]")
 	newCmd.Flags().String("ci-provider", "none", "specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci]")
 	newCmd.Flags().String("vcs", "git", "specify the Version control system you would like to use [none, git, bzr]")
-	newCmd.Flags().Int("bootstrap", 3, "specify version for Bootstrap [3, 4]")
+	newCmd.Flags().Int("bootstrap", 4, "specify version for Bootstrap [3, 4]")
 	viper.BindPFlags(newCmd.Flags())
 	cfgFile := newCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.buffalo.yaml)")
 	skipConfig := newCmd.Flags().Bool("skip-config", false, "skips using the config file")

--- a/buffalo/cmd/new_test.go
+++ b/buffalo/cmd/new_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Bootstrap4_Default(t *testing.T) {
+	r := require.New(t)
+	f, err := newCmd.Flags().GetInt("bootstrap")
+	r.NoError(err)
+	r.Equal(4, f)
+}


### PR DESCRIPTION
Bootstrap was set to default to `4` here: https://github.com/gobuffalo/buffalo/pull/1021/files#diff-5d01d5c891e4aea766821d1009e66912R29

It regressed to `3` here: https://github.com/gobuffalo/buffalo/pull/1119/files#diff-00e5b9d3695f2772e4d4422b4fee4787R155