### PR TITLE
Replace assets map Mutex with a RWMutex

### DIFF
--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var assetsMutex = &sync.Mutex{}
+var assetsMutex = &sync.RWMutex{}
 var assetMap map[string]string
 
 func loadManifest(manifest string) error {
@@ -22,10 +22,9 @@ func loadManifest(manifest string) error {
 }
 
 func assetPathFor(file string) string {
-	assetsMutex.Lock()
-	defer assetsMutex.Unlock()
-
+	assetsMutex.RLock()
 	filePath := assetMap[file]
+	assetsMutex.RUnlock()
 	if filePath == "" {
 		filePath = file
 	}


### PR DESCRIPTION
Once the assets map is loaded, it shouldn't change often. So, soften the read
access makes sense (and won't block rendering).