### PR TITLE
Ensure no information lost in binding time format

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -30,7 +30,7 @@ var timeFormats = []string{
 	"2006-01-02T15:04:05Z07:00",
 	"01/02/2006",
 	"2006-01-02",
-	"2006-01-02T03:04",
+	"2006-01-02T15:04",
 	time.ANSIC,
 	time.UnixDate,
 	time.RubyDate,

--- a/binding/binding_test.go
+++ b/binding/binding_test.go
@@ -14,9 +14,36 @@ func TestParseTimeErrorParsing(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
+
 	r := require.New(t)
-	tt, err := parseTime([]string{"2017-01-01"})
-	r.NoError(err)
-	expected := time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC)
-	r.Equal(expected, tt)
+
+	testCases := []struct {
+		input     string
+		expected  time.Time
+		expectErr bool
+	}{
+		{
+			input:     "2017-01-01",
+			expected:  time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expectErr: false,
+		},
+		{
+			input:     "2018-07-13T15:34",
+			expected:  time.Date(2018, time.July, 13, 15, 34, 0, 0, time.UTC),
+			expectErr: false,
+		},
+		{
+			input:     "2018-20-10T30:15",
+			expected:  time.Time{},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tt, err := parseTime([]string{tc.input})
+		if !tc.expectErr {
+			r.NoError(err)
+		}
+		r.Equal(tc.expected, tt)
+	}
 }


### PR DESCRIPTION
One of the currently registered time formats loses whether the parsed time is in AM or PM. Furthermore, it could fail if the input time is within the hours 13-to-00.

Fixes #1169 