### PR TITLE
feature: download renderer to facilitate file downloads

### DIFF
--- a/render/download.go
+++ b/render/download.go
@@ -1,0 +1,62 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strconv"
+)
+
+type downloadRenderer struct {
+	data     []byte
+	filename string
+	writer   http.ResponseWriter
+}
+
+func (r downloadRenderer) ContentType() string {
+	ext := filepath.Ext(r.filename)
+	t := mime.TypeByExtension(ext)
+	if t == "" {
+		t = "application/octet-stream"
+	}
+
+	return t
+}
+
+func (r downloadRenderer) Render(w io.Writer, d Data) error {
+	r.writer.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=%s", r.filename))
+	r.writer.Header().Add("Content-Length", strconv.Itoa(len(r.data)))
+
+	_, err := w.Write(r.data)
+	return err
+}
+
+// Download renders a file attachment automatically setting following headers:
+//
+//   Content-Type
+//   Content-Length
+//   Content-Disposition
+//
+// Content-Type is set using mime#TypeByExtension with the filename's extension. Content-Type will default to
+// application/octet-stream if using a filename with an unknown extension.
+func Download(data []byte, filename string, writer http.ResponseWriter) Renderer {
+	return downloadRenderer{
+		data:     data,
+		filename: filename,
+		writer:   writer,
+	}
+}
+
+// Download renders a file attachment automatically setting following headers:
+//
+//   Content-Type
+//   Content-Length
+//   Content-Disposition
+//
+// Content-Type is set using mime#TypeByExtension with the filename's extension. Content-Type will default to
+// application/octet-stream if using a filename with an unknown extension.
+func (e *Engine) Download(data []byte, filename string, writer http.ResponseWriter) Renderer {
+	return Download(data, filename, writer)
+}

--- a/render/download_test.go
+++ b/render/download_test.go
@@ -1,0 +1,60 @@
+package render_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gobuffalo/buffalo/render"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_DownloadWithWellKnownExtension(t *testing.T) {
+	assert := require.New(t)
+	data := []byte("data")
+
+	type di func([]byte, string, http.ResponseWriter) render.Renderer
+	table := []di{
+		render.Download,
+		render.New(render.Options{}).Download,
+	}
+
+	for _, d := range table {
+		recorder := httptest.NewRecorder()
+		re := d(data, "filename.pdf", recorder)
+		bb := new(bytes.Buffer)
+		err := re.Render(bb, nil)
+
+		assert.NoError(err)
+		assert.Equal(data, bb.Bytes())
+		assert.Equal(strconv.Itoa(len(data)), recorder.Header().Get("Content-Length"))
+		assert.Equal("attachment; filename=filename.pdf", recorder.Header().Get("Content-Disposition"))
+		assert.Equal("application/pdf", re.ContentType())
+	}
+}
+
+func Test_DownloadWithUnknownExtension(t *testing.T) {
+	assert := require.New(t)
+	data := []byte("data")
+
+	type di func([]byte, string, http.ResponseWriter) render.Renderer
+	table := []di{
+		render.Download,
+		render.New(render.Options{}).Download,
+	}
+
+	for _, d := range table {
+		recorder := httptest.NewRecorder()
+		re := d(data, "filename", recorder)
+		bb := new(bytes.Buffer)
+		err := re.Render(bb, nil)
+
+		assert.NoError(err)
+		assert.Equal(data, bb.Bytes())
+		assert.Equal(strconv.Itoa(len(data)), recorder.Header().Get("Content-Length"))
+		assert.Equal("attachment; filename=filename", recorder.Header().Get("Content-Disposition"))
+		assert.Equal("application/octet-stream", re.ContentType())
+	}
+}


### PR DESCRIPTION
This is what I'm using for file downloads in my projects so I thought I'd open a PR to see if there's any desire for it in Buffalo proper. Example usage:

```go
c.Render(http.StatusOK, r.Download(c, "report.pdf", bytes.NewReader(pdfBytes))
```