### PR TITLE
Remove logger need from the render package

### DIFF
--- a/render/template.go
+++ b/render/template.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"fmt"
 	"html/template"
 	"io"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	// this blank import is here because dep doesn't
 	// handle transitive dependencies correctly
@@ -119,8 +119,7 @@ func (s templateRenderer) exec(name string, data Data) (template.HTML, error) {
 	for _, ext := range s.exts(name) {
 		te, ok := s.TemplateEngines[ext]
 		if !ok {
-			logrus.Errorf("could not find a template engine for %s\n", ext)
-			continue
+			return "", fmt.Errorf("could not find a template engine for %s", ext)
 		}
 		body, err = te(body, data, helpers)
 		if err != nil {


### PR DESCRIPTION
If a rendering engine is not found for a given extension, it should just return an error.