### PR TITLE
Add XML header with version and encoding when rendering an XML response

### DIFF
--- a/render/xml.go
+++ b/render/xml.go
@@ -14,6 +14,7 @@ func (s xmlRenderer) ContentType() string {
 }
 
 func (s xmlRenderer) Render(w io.Writer, data Data) error {
+	io.WriteString(w, xml.Header)
 	enc := xml.NewEncoder(w)
 	enc.Indent("", "  ")
 	return enc.Encode(s.value)

--- a/render/xml_test.go
+++ b/render/xml_test.go
@@ -29,6 +29,6 @@ func Test_XML(t *testing.T) {
 		bb := &bytes.Buffer{}
 		err := re.Render(bb, nil)
 		r.NoError(err)
-		r.Equal("<user>\n  <Name>mark</Name>\n</user>", strings.TrimSpace(bb.String()))
+		r.Equal("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<user>\n  <Name>mark</Name>\n</user>", strings.TrimSpace(bb.String()))
 	}
 }


### PR DESCRIPTION
From short chat with @markbates in Gophers #buffalo channel, add header to all rendered XML responses