### PR TITLE
Add post initializers support

### DIFF
--- a/options.go
+++ b/options.go
@@ -52,16 +52,21 @@ type Options struct {
 	// PreHandlers are http.Handlers that are called between the http.Server
 	// and the buffalo Application.
 	PreHandlers []http.Handler
-	// PreWare takes an http.Handler and returns and http.Handler
+	// PreWares take an http.Handler and returns and http.Handler
 	// and acts as a pseudo-middleware between the http.Server and
 	// a Buffalo application.
 	PreWares []PreWare
+	// PostInitializers handle the stuff you may want to init, but requiring the app to be ready.
+	PostInitializers []PostInitializer
 
 	Context context.Context
 
 	cancel context.CancelFunc
 	Prefix string
 }
+
+// PostInitializer handles the stuff you may want to init, but requiring the app to be ready.
+type PostInitializer func(app *App) error
 
 // PreWare takes an http.Handler and returns and http.Handler
 // and acts as a pseudo-middleware between the http.Server and
@@ -96,6 +101,9 @@ func optionsWithDefaults(opts Options) Options {
 	}
 	if opts.PreHandlers == nil {
 		opts.PreHandlers = []http.Handler{}
+	}
+	if opts.PostInitializers == nil {
+		opts.PostInitializers = []PostInitializer{}
 	}
 
 	if opts.Context == nil {

--- a/server.go
+++ b/server.go
@@ -78,6 +78,13 @@ func (a *App) Serve(srvs ...servers.Server) error {
 		}(s)
 	}
 
+	// Run post initializers
+	for _, f := range a.PostInitializers {
+		if err := f(a); err != nil {
+			a.Stop(err)
+		}
+	}
+
 	<-ctx.Done()
 	return a.Context.Err()
 }


### PR DESCRIPTION
PostInitializers introduces a new way to handle a common pattern:
when you want to init some stuff or start a service just after the app
started successfully, you usually just drop the relevant code after the
routes init, in the `if app == nil {` block.

This way to do is just a workaround, and doing so can result in multiple
init, if you use `App()` more than once.

PostInitializers proposes a cleaner solution for this pattern. It allows
the user to define a slice of handlers to execute after the app starts.