### PR TITLE
Add an integration test for buffalo version command

### DIFF
--- a/buffalo/cmd/version_test.go
+++ b/buffalo/cmd/version_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_VersionCmd(t *testing.T) {
+	r := require.New(t)
+
+	c := RootCmd
+	c.SetArgs([]string{
+		"version",
+	})
+	err := c.Execute()
+	r.NoError(err)
+}


### PR DESCRIPTION
Let's start having integration tests written in Go, to ensure it works on every tested plateform (not just Linux/Docker).