### PR TITLE
Start new app integration tests

### DIFF
--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/spf13/pflag"
+
 	"github.com/markbates/inflect"
 	"github.com/sirupsen/logrus"
 
@@ -59,6 +61,13 @@ var newCmd = &cobra.Command{
 	Use:   "new [name]",
 	Short: "Creates a new Buffalo application",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Restore default values after usage (useful for testing)
+		defer func() {
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				f.Value.Set(f.DefValue)
+			})
+			viper.BindPFlags(cmd.Flags())
+		}()
 		if len(args) == 0 {
 			return errors.New("you must enter a name for your new application")
 		}

--- a/buffalo/cmd/new_test.go
+++ b/buffalo/cmd/new_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/gobuffalo/pop"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,4 +14,38 @@ func Test_Bootstrap4_Default(t *testing.T) {
 	f, err := newCmd.Flags().GetInt("bootstrap")
 	r.NoError(err)
 	r.Equal(4, f)
+}
+
+func Test_NewCmd_NoName(t *testing.T) {
+	r := require.New(t)
+	c := RootCmd
+	c.SetArgs([]string{
+		"new",
+	})
+	err := c.Execute()
+	r.EqualError(err, "you must enter a name for your new application")
+}
+
+func Test_NewCmd_InvalidDBType(t *testing.T) {
+	r := require.New(t)
+	c := RootCmd
+	c.SetArgs([]string{
+		"new",
+		"coke",
+		"--db-type",
+		"a",
+	})
+	err := c.Execute()
+	r.EqualError(err, fmt.Sprintf("Unknown db-type a expecting one of %s", strings.Join(pop.AvailableDialects, ", ")))
+}
+
+func Test_NewCmd_ForbiddenAppName(t *testing.T) {
+	r := require.New(t)
+	c := RootCmd
+	c.SetArgs([]string{
+		"new",
+		"buffalo",
+	})
+	err := c.Execute()
+	r.EqualError(err, "name buffalo is not allowed, try a different application name")
 }

--- a/generators/newapp/generator.go
+++ b/generators/newapp/generator.go
@@ -80,7 +80,7 @@ func (g Generator) Validate() error {
 	}
 
 	if !nameRX.MatchString(string(g.Name)) {
-		return fmt.Errorf("name %s is not allowed, application name can only be contain [a-Z0-9-_]", g.Name)
+		return fmt.Errorf("name %s is not allowed, application name can only contain [a-Z0-9-_]", g.Name)
 	}
 
 	if s, _ := os.Stat(g.Root); s != nil {


### PR DESCRIPTION
Add new integration tests for `buffalo new app` and fix a typo in an error message.