### PR TITLE
Replace yarn calls with yarnpkg alias to prevent conflict with Hadoop YARN

### DIFF
--- a/buffalo/cmd/dev.go
+++ b/buffalo/cmd/dev.go
@@ -74,7 +74,7 @@ func startWebpack(ctx context.Context) error {
 	}
 
 	if _, err := os.Stat(filepath.Join(app.Root, "node_modules")); err != nil {
-		tool := "yarn"
+		tool := "yarnpkg"
 		if !app.WithYarn {
 			tool = "npm"
 		}

--- a/buffalo/cmd/fix/npm.go
+++ b/buffalo/cmd/fix/npm.go
@@ -81,7 +81,7 @@ func PackageJSONCheck(r *Runner) error {
 	os.RemoveAll(filepath.Join(r.App.Root, "node_modules"))
 	var cmd *exec.Cmd
 	if r.App.WithYarn {
-		cmd = exec.Command("yarn", "install")
+		cmd = exec.Command("yarnpkg", "install")
 	} else {
 		cmd = exec.Command("npm", "install")
 	}

--- a/buffalo/cmd/info.go
+++ b/buffalo/cmd/info.go
@@ -71,7 +71,7 @@ func runInfoCmds() error {
 		{"Go", envy.Get("GO_BIN", "go"), exec.Command(envy.Get("GO_BIN", "go"), "env"), "\n### Go Env\n"},
 		{"Node", "node", exec.Command("node", "--version"), "\n### Node Version\n"},
 		{"NPM", "npm", exec.Command("npm", "--version"), "\n### NPM Version\n"},
-		{"Yarn", "yarn", exec.Command("yarn", "--version"), "\n### Yarn Version\n"},
+		{"Yarn", "yarnpkg", exec.Command("yarn", "--version"), "\n### Yarn Version\n"},
 		{"PostgreSQL", "pg_ctl", exec.Command("pg_ctl", "--version"), "\n### PostgreSQL Version\n"},
 		{"MySQL", "mysql", exec.Command("mysql", "--version"), "\n### MySQL Version\n"},
 		{"SQLite", "sqlite3", exec.Command("sqlite3", "--version"), "\n### SQLite Version\n"},

--- a/buffalo/cmd/setup.go
+++ b/buffalo/cmd/setup.go
@@ -191,13 +191,13 @@ func yarnCheck(app meta.App) error {
 	if err := nodeCheck(app); err != nil {
 		return errors.WithStack(err)
 	}
-	if _, err := exec.LookPath("yarn"); err != nil {
+	if _, err := exec.LookPath("yarnpkg"); err != nil {
 		err := run(exec.Command("npm", "install", "-g", "yarn"))
 		if err != nil {
 			return errors.Errorf("This application require yarn, and we could not find it installed on your system. We tried to install it for you, but ran into the following error:\n%s", err)
 		}
 	}
-	if err := run(exec.Command("yarn", "install", "--no-progress")); err != nil {
+	if err := run(exec.Command("yarnpkg", "install", "--no-progress")); err != nil {
 		return errors.Errorf("We encountered the following error when trying to install your asset dependencies using yarn:\n%s", err)
 	}
 	return nil

--- a/generators/assets/webpack/webpack.go
+++ b/generators/assets/webpack/webpack.go
@@ -35,7 +35,7 @@ func (w Generator) Run(root string, data makr.Data) error {
 		return standard.Run(root, data)
 	}
 
-	command := "yarn"
+	command := "yarnpkg"
 
 	if !w.WithYarn {
 		command = "npm"
@@ -65,7 +65,7 @@ func (w Generator) Run(root string, data makr.Data) error {
 
 func installYarn(data makr.Data) error {
 	// if there's no yarn, install it!
-	_, err := exec.LookPath("yarn")
+	_, err := exec.LookPath("yarnpkg")
 	// A new makr is necessary to have yarn available in path
 	if err != nil {
 		yg := makr.New()


### PR DESCRIPTION
Fixes #1217.

Since https://github.com/yarnpkg/yarn/issues/673, `yarn` defines an alias for itself: "yarnpkg". Its usage prevents conflicts with tools using the same name (such as Hadoop YARN, a common tool for Data scientists).