### PR TITLE
Clarify destroy confirm action

### DIFF
--- a/buffalo/cmd/destroy/resource.go
+++ b/buffalo/cmd/destroy/resource.go
@@ -54,7 +54,7 @@ func confirm(msg string) bool {
 }
 
 func removeTemplates(fileName string) {
-	if YesToAll || confirm("Want to remove templates? (Y/n)") {
+	if YesToAll || confirm("Want to remove templates? (y/N)") {
 		templatesFolder := filepath.Join("templates", fileName)
 		logrus.Infof("- Deleted %v folder\n", templatesFolder)
 		os.RemoveAll(templatesFolder)
@@ -62,7 +62,7 @@ func removeTemplates(fileName string) {
 }
 
 func removeActions(fileName string) error {
-	if YesToAll || confirm("Want to remove actions? (Y/n)") {
+	if YesToAll || confirm("Want to remove actions? (y/N)") {
 		logrus.Infof("- Deleted %v\n", fmt.Sprintf("actions/%v.go", fileName))
 		os.Remove(filepath.Join("actions", fmt.Sprintf("%v.go", fileName)))
 
@@ -91,13 +91,13 @@ func removeActions(fileName string) error {
 }
 
 func removeLocales(fileName string) {
-	if YesToAll || confirm("Want to remove locales? (Y/n)") {
+	if YesToAll || confirm("Want to remove locales? (y/N)") {
 		removeMatch("locales", fmt.Sprintf("%v.*.yaml", fileName))
 	}
 }
 
 func removeModel(name string) {
-	if YesToAll || confirm("Want to remove model? (Y/n)") {
+	if YesToAll || confirm("Want to remove model? (y/N)") {
 		modelFileName := inflect.Singularize(inflect.Underscore(name))
 
 		os.Remove(filepath.Join("models", fmt.Sprintf("%v.go", modelFileName)))
@@ -109,7 +109,7 @@ func removeModel(name string) {
 }
 
 func removeMigrations(fileName string) {
-	if YesToAll || confirm("Want to remove migrations? (Y/n)") {
+	if YesToAll || confirm("Want to remove migrations? (y/N)") {
 		removeMatch("migrations", fmt.Sprintf("*_create_%v.up.*", fileName))
 		removeMatch("migrations", fmt.Sprintf("*_create_%v.down.*", fileName))
 	}


### PR DESCRIPTION
Having the confirm message with an uppercase `Y` makes it
appear that hitting enter will default to yes for the destroy action,
but it defaults to no.

Changing the case of the y/n indicators makes this clearer.

Closes #1275