### PR TITLE
upgrading babel to remove npm warnings

### DIFF
--- a/buffalo/cmd/destroy/resource.go
+++ b/buffalo/cmd/destroy/resource.go
@@ -54,7 +54,7 @@ func confirm(msg string) bool {
 }
 
 func removeTemplates(fileName string) {
-	if YesToAll || confirm("Want to remove templates? (Y/n)") {
+	if YesToAll || confirm("Want to remove templates? (y/N)") {
 		templatesFolder := filepath.Join("templates", fileName)
 		logrus.Infof("- Deleted %v folder\n", templatesFolder)
 		os.RemoveAll(templatesFolder)
@@ -62,7 +62,7 @@ func removeTemplates(fileName string) {
 }
 
 func removeActions(fileName string) error {
-	if YesToAll || confirm("Want to remove actions? (Y/n)") {
+	if YesToAll || confirm("Want to remove actions? (y/N)") {
 		logrus.Infof("- Deleted %v\n", fmt.Sprintf("actions/%v.go", fileName))
 		os.Remove(filepath.Join("actions", fmt.Sprintf("%v.go", fileName)))
 
@@ -91,13 +91,13 @@ func removeActions(fileName string) error {
 }
 
 func removeLocales(fileName string) {
-	if YesToAll || confirm("Want to remove locales? (Y/n)") {
+	if YesToAll || confirm("Want to remove locales? (y/N)") {
 		removeMatch("locales", fmt.Sprintf("%v.*.yaml", fileName))
 	}
 }
 
 func removeModel(name string) {
-	if YesToAll || confirm("Want to remove model? (Y/n)") {
+	if YesToAll || confirm("Want to remove model? (y/N)") {
 		modelFileName := inflect.Singularize(inflect.Underscore(name))
 
 		os.Remove(filepath.Join("models", fmt.Sprintf("%v.go", modelFileName)))
@@ -109,7 +109,7 @@ func removeModel(name string) {
 }
 
 func removeMigrations(fileName string) {
-	if YesToAll || confirm("Want to remove migrations? (Y/n)") {
+	if YesToAll || confirm("Want to remove migrations? (y/N)") {
 		removeMatch("migrations", fmt.Sprintf("*_create_%v.up.*", fileName))
 		removeMatch("migrations", fmt.Sprintf("*_create_%v.down.*", fileName))
 	}

--- a/generators/assets/webpack/templates/dot-babelrc.tmpl
+++ b/generators/assets/webpack/templates/dot-babelrc.tmpl
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }

--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -8,7 +8,7 @@
     {{ if eq .opts.Bootstrap 3 -}}
     "bootstrap-sass": "~3.3.7",
     {{ else -}}
-    "bootstrap": "4.1.1",
+    "bootstrap": "4.1.3",
     "popper.js": "^1.14.3",
     {{ end -}}
     "font-awesome": "~4.7.0",
@@ -22,7 +22,7 @@
     "babel-loader": "^8.0.0-beta.6", 
     "webpack-clean-obsolete-chunks": "^0.4.0",
     "copy-webpack-plugin": "~4.5.1",
-    "css-loader": "~0.28.11",
+    "css-loader": "~1.0.0",
     "expose-loader": "~0.7.5",
     "file-loader": "~1.1.11",
     "gopherjs-loader": "^0.0.1",
@@ -34,7 +34,7 @@
     "uglifyjs-webpack-plugin": "~1.2.4",
     "url-loader": "~1.0.1",
     "webpack": "~4.5.0",
-    "webpack-cli": "2.0.14",
+    "webpack-cli": "3.1.0",
     "webpack-livereload-plugin":"2.1.1",
     "webpack-manifest-plugin": "~2.0.0"
   }

--- a/generators/assets/webpack/templates/package.json.tmpl
+++ b/generators/assets/webpack/templates/package.json.tmpl
@@ -16,10 +16,10 @@
     "jquery-ujs": "~1.2.2"
   },
   "devDependencies": {
-    "babel-cli": "~6.26.0",
-    "babel-core": "~6.26.0",
-    "babel-loader": "~7.1.2",
-    "babel-preset-env": "~1.5.2",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "babel-loader": "^8.0.0-beta.6", 
     "webpack-clean-obsolete-chunks": "^0.4.0",
     "copy-webpack-plugin": "~4.5.1",
     "css-loader": "~0.28.11",


### PR DESCRIPTION
This one upgrades babel to use version 7 and with this the npm warnings mentioned in #1273 disappear.