### PR TITLE
Changes default postgres password in docker image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,6 +10,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash \
 && apt-get install -y -q build-essential nodejs sqlite3 libsqlite3-dev postgresql postgresql-contrib libpq-dev mysql-client vim \
 && rm -rf /var/lib/apt/lists/*
 
+RUN service postgresql start && \
+    su -c "psql -c \"ALTER USER postgres  WITH PASSWORD 'postgres';\"" - postgres
 
 RUN go get -u github.com/golang/dep/cmd/dep \
 && go get -v -u github.com/gobuffalo/makr \


### PR DESCRIPTION
This PR changes the default password for the postgres user in the buffalo build image, this is useful to use the build image to run your tests (give it already has postgres installed).