### PR TITLE
Fix buffalo-pop path

### DIFF
--- a/generators/soda/soda.go
+++ b/generators/soda/soda.go
@@ -28,9 +28,9 @@ func (sd Generator) Run(root string, data makr.Data) error {
 	f.Should = should
 	g.Add(f)
 
-	c := makr.NewCommand(makr.GoGet("github.com/gobuffalo/buffalo-pop/..."))
+	c := makr.NewCommand(makr.GoGet("github.com/gobuffalo/buffalo-pop"))
 	if dt, ok := data["db-type"]; ok && dt == "sqlite3" {
-		c = makr.NewCommand(makr.GoGet("github.com/gobuffalo/buffalo-pop/...", "-tags", "sqlite"))
+		c = makr.NewCommand(makr.GoGet("github.com/gobuffalo/buffalo-pop", "-tags", "sqlite"))
 	}
 	c.Should = should
 	g.Add(c)


### PR DESCRIPTION
This patch is fixing buffalo-pop issue that I found. GO modules=on

```
      create  models/models.go                 
      create  models/models_test.go            
      create  grifts/db.go                     
         run  go get github.com/gobuffalo/buffalo-pop/...                                      
     go: finding github.com/gobuffalo/buffalo-pop/... latest                                        
     go: finding github.com/gobuffalo/buffalo-pop latest                                            
     go get github.com/gobuffalo/buffalo-pop/...: no matching versions for query "latest"
```