### PR TITLE
Add utf8 to content type for html

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -133,7 +133,7 @@ func productionErrorResponseFor(status int) []byte {
 
 func defaultErrorHandler(status int, origErr error, c Context) error {
 	env := c.Value("env")
-	ct := defaults.String(httpx.ContentType(c.Request()), "text/html")
+	ct := defaults.String(httpx.ContentType(c.Request()), "text/html; charset=utf-8")
 	c.Response().Header().Set("content-type", ct)
 
 	c.Logger().Error(origErr)

--- a/errors_test.go
+++ b/errors_test.go
@@ -20,7 +20,7 @@ func Test_defaultErrorHandler_SetsContentType(t *testing.T) {
 	res := w.HTML("/").Get()
 	r.Equal(401, res.Code)
 	ct := res.Header().Get("content-type")
-	r.Equal("text/html", ct)
+	r.Equal("text/html; charset=utf-8", ct)
 }
 
 func Test_PanicHandler(t *testing.T) {

--- a/render/html.go
+++ b/render/html.go
@@ -33,7 +33,7 @@ func (e *Engine) HTML(names ...string) Renderer {
 	}
 	hr := &templateRenderer{
 		Engine:      e,
-		contentType: "text/html",
+		contentType: "text/html; charset=utf-8",
 		names:       names,
 	}
 	return hr

--- a/render/html_test.go
+++ b/render/html_test.go
@@ -35,7 +35,7 @@ func Test_HTML(t *testing.T) {
 		}).HTML
 
 		re := j(filepath.Base(tmpFile.Name()))
-		r.Equal("text/html", re.ContentType())
+		r.Equal("text/html; charset=utf-8", re.ContentType())
 		bb := &bytes.Buffer{}
 		err = re.Render(bb, map[string]interface{}{"name": "Mark"})
 		r.NoError(err)
@@ -61,7 +61,7 @@ func Test_HTML(t *testing.T) {
 			r := require.New(sst)
 			h := re.HTML(filepath.Base(tmpFile.Name()))
 
-			r.Equal("text/html", h.ContentType())
+			r.Equal("text/html; charset=utf-8", h.ContentType())
 			bb := &bytes.Buffer{}
 			err = h.Render(bb, map[string]interface{}{"name": "Mark"})
 			r.NoError(err)
@@ -78,7 +78,7 @@ func Test_HTML(t *testing.T) {
 			r.NoError(err)
 			h := re.HTML(filepath.Base(tmpFile.Name()), filepath.Base(nlayout.Name()))
 
-			r.Equal("text/html", h.ContentType())
+			r.Equal("text/html; charset=utf-8", h.ContentType())
 			bb := &bytes.Buffer{}
 			err = h.Render(bb, map[string]interface{}{"name": "Mark"})
 			r.NoError(err)

--- a/render/markdown_test.go
+++ b/render/markdown_test.go
@@ -38,7 +38,7 @@ func Test_Markdown(t *testing.T) {
 
 		for _, j := range table {
 			re := j(filepath.Base(tmpFile.Name()))
-			r.Equal("text/html", re.ContentType())
+			r.Equal("text/html; charset=utf-8", re.ContentType())
 			bb := &bytes.Buffer{}
 			err = re.Render(bb, map[string]interface{}{"name": "Mark"})
 			r.NoError(err)
@@ -61,7 +61,7 @@ func Test_Markdown(t *testing.T) {
 			TemplatesBox: packr.NewBox(tmpDir),
 		}).HTML(filepath.Base(tmpFile.Name()))
 
-		r.Equal("text/html", re.ContentType())
+		r.Equal("text/html; charset=utf-8", re.ContentType())
 		bb := &bytes.Buffer{}
 		err = re.Render(bb, map[string]interface{}{"name": "Mark"})
 		r.NoError(err)

--- a/render/partials_test.go
+++ b/render/partials_test.go
@@ -35,7 +35,7 @@ func Test_Template_Partial_WithoutExtension(t *testing.T) {
 	err := withHTMLFile("index.html", `<%= partial("foo") %>`, func(e *Engine) {
 		err := withHTMLFile("_foo.html", "Foo > <%= name %>", func(e *Engine) {
 
-			re := e.Template("text/html", "index.html")
+			re := e.Template("text/html; charset=utf-8", "index.html")
 			bb := &bytes.Buffer{}
 			err := re.Render(bb, Data{"name": "Mark"})
 			r.NoError(err)

--- a/render/render.go
+++ b/render/render.go
@@ -42,7 +42,7 @@ func New(opts Options) *Engine {
 	}
 
 	if opts.DefaultContentType == "" {
-		opts.DefaultContentType = "text/html"
+		opts.DefaultContentType = "text/html; charset=utf-8"
 	}
 
 	e := &Engine{

--- a/render/template_test.go
+++ b/render/template_test.go
@@ -82,7 +82,7 @@ func Test_AssetPath(t *testing.T) {
 		_, err = tmpFile.Write([]byte("<%= assetPath(\"" + original + "\") %>"))
 		r.NoError(err)
 
-		result := re("text/html", filepath.Base(tmpFile.Name()))
+		result := re("text/html; charset=utf-8", filepath.Base(tmpFile.Name()))
 
 		bb := &bytes.Buffer{}
 		err = result.Render(bb, render.Data{})
@@ -123,7 +123,7 @@ func Test_AssetPathNoManifest(t *testing.T) {
 		_, err = tmpFile.Write([]byte("<%= assetPath(\"" + original + "\") %>"))
 		r.NoError(err)
 
-		result := re("text/html", filepath.Base(tmpFile.Name()))
+		result := re("text/html; charset=utf-8", filepath.Base(tmpFile.Name()))
 
 		bb := &bytes.Buffer{}
 		err = result.Render(bb, render.Data{})
@@ -166,7 +166,7 @@ func Test_AssetPathManifestCorrupt(t *testing.T) {
 		_, err = tmpFile.Write([]byte("<%= assetPath(\"" + original + "\") %>"))
 		r.NoError(err)
 
-		result := re("text/html", filepath.Base(tmpFile.Name()))
+		result := re("text/html; charset=utf-8", filepath.Base(tmpFile.Name()))
 
 		bb := &bytes.Buffer{}
 		err = result.Render(bb, render.Data{})


### PR DESCRIPTION
Closes issue #1312 by changing the Content-Type headers from 'text/html'  to 'text/html; charset=utf-8' for html output. 
