### PR TITLE
Skip -i flag in go build if modules are enabled

### DIFF
--- a/buffalo/cmd/build/bin.go
+++ b/buffalo/cmd/build/bin.go
@@ -5,13 +5,18 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/envy"
+	"github.com/gobuffalo/genny/movinglater/gotools/gomods"
 	"github.com/pkg/errors"
 )
 
 func (b *Builder) buildBin() error {
-	buildArgs := []string{"build", "-i"}
+	buildArgs := []string{"build"}
 	if b.Debug {
 		buildArgs = append(buildArgs, "-v")
+	}
+
+	if !gomods.On() {
+		buildArgs = append(buildArgs, "-i")
 	}
 
 	tf := b.App.BuildTags(b.Environment, b.Tags...)


### PR DESCRIPTION
Using -i flag when running go build is not useful with go modules enabled
and in some cases can lead to a bug, with go trying to rebuild
shipped vendorized dependencies as described in this issue
golang/go#27285.
With this commit we check if go modules are enabled and we drop the -i
flag accordingly.