### PR TITLE
Adds some inline help for webpack

### DIFF
--- a/generators/assets/webpack/templates/webpack.config.js.tmpl
+++ b/generators/assets/webpack/templates/webpack.config.js.tmpl
@@ -72,6 +72,9 @@ const configurator = {
   },
 
   buildConfig: function(){
+    // NOTE: If you are having issues with this not being set "properly", make
+    // sure your GO_ENV is set properly as `buffalo build` overrides NODE_ENV
+    // with whatever GO_ENV is set to or "development".
     const env = process.env.NODE_ENV || "development";
 
     var config = {


### PR DESCRIPTION
Not realizing that `NODE_ENV` isn't respected in `buffalo build` cost us a good bit of time today, so in the hopes that we can save someone else the pain I would like to put this note here.