### PR TITLE
Fix a race condition in DefaultContext.data

### DIFF
--- a/default_context.go
+++ b/default_context.go
@@ -69,7 +69,9 @@ func (d *DefaultContext) Param(key string) string {
 // Set a value onto the Context. Any value set onto the Context
 // will be automatically available in templates.
 func (d *DefaultContext) Set(key string, value interface{}) {
+	d.moot.Lock()
 	d.data[key] = value
+	d.moot.Unlock()
 }
 
 // Value that has previously stored on the context.


### PR DESCRIPTION
There were `RLock` calls around all the accesses of the `DefaultContext.data` map, but no `Lock` around the write in the `Set` method. This adds that `Lock`. 

Updating to v0.13.0 caused my application to start panicing with `fatal error: concurrent map iteration and map write`. While writing up the issue, I found the problem.

I'd recommend considering to make this a patch update for 0.13.0.