### PR TITLE
dont add a go.mo file when go modules are turned off

### DIFF
--- a/generators/newapp/new.go
+++ b/generators/newapp/new.go
@@ -35,6 +35,9 @@ func (a Generator) Run(root string, data makr.Data) error {
 		defer os.RemoveAll(filepath.Join(a.Root, "locales"))
 		defer os.RemoveAll(filepath.Join(a.Root, "public"))
 	}
+	if !a.App.WithModules {
+		defer os.Remove(filepath.Join(a.Root, "go.mod"))
+	}
 	if a.Force {
 		os.RemoveAll(a.Root)
 	}


### PR DESCRIPTION
go.mod file was being generated even when Go modules are turned off.