### PR TITLE
Negotiate Response Content-Type from request's Accept header.

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -82,7 +82,7 @@ func RegisteredTypes() []string {
 	defer lock.Unlock()
 
 	types := []string{}
-	for name, _ := range binders {
+	for name := range binders {
 		types = append(types, name)
 	}
 	return types

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -75,6 +75,19 @@ func Register(contentType string, fn Binder) {
 	binders[strings.ToLower(contentType)] = fn
 }
 
+// RegisteredTypes gets a list of the Content-Types that have been registered
+// with Binders and can be used in negotiating a response Content-Type.
+func RegisteredTypes() []string {
+	lock.Lock()
+	defer lock.Unlock()
+
+	types := []string{}
+	for name, _ := range binders {
+		types = append(types, name)
+	}
+	return types
+}
+
 // Exec will bind the interface to the request.Body. The type of binding
 // is dependent on the "Content-Type" for the request. If the type
 // is "application/json" it will use "json.NewDecoder". If the type

--- a/context.go
+++ b/context.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gobuffalo/buffalo/binding"
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/x/httpx"
+	"github.com/golang/gddo/httputil"
 	"github.com/gorilla/mux"
 )
 
@@ -62,7 +62,7 @@ func (a *App) newContext(info RouteInfo, res http.ResponseWriter, req *http.Requ
 
 	session := a.getSession(req, res)
 
-	ct := httpx.ContentType(req)
+	ct := httputil.NegotiateContentType(req, binding.RegisteredTypes(), "")
 	contextData := map[string]interface{}{
 		"app":           a,
 		"env":           a.Env,


### PR DESCRIPTION
Resolves #1148

This changes the default Context to negotiate the response `Content-Type` using the request's `Accept` header exclusively, instead of including the request's `Content-Type` in the negotiation. Failed negotiation will default to using `render.Options#DefaultContentType`. (This is important because Internet Explorer does not pass an Accept header that negotiates HTML.)

### This is not backwards compatible

HTTP clients using `Content-Type` instead of `Accept` in their request headers will not work the same way. Code that overrides these values (such as those using https://github.com/gobuffalo/mw-contenttype) will no longer have the desired effect. They should be removed in favor of the `DefaultContentType` option or a middleware that sets the `Accept` header.

~~https://github.com/gobuffalo/httptest/pull/2 is needed for tests to pass~~ Merged!

