### PR TITLE
integrated with plush's own partial (and added testcases)

### DIFF
--- a/render/js.go
+++ b/render/js.go
@@ -1,11 +1,8 @@
 package render
 
 import (
-	"html/template"
-	"strings"
-
 	"github.com/gobuffalo/plush"
-	"github.com/pkg/errors"
+	"github.com/markbates/oncer"
 )
 
 // JavaScript renders the named files using the 'application/javascript'
@@ -41,28 +38,8 @@ func (e *Engine) JavaScript(names ...string) Renderer {
 }
 
 // JSTemplateEngine renders files with a `.js` extension through Plush.
-// It also implements a new `partial` helper that will run non-JS partials
-// through `JSEscapeString` before injecting.
+// Deprecated: use github.com/gobuffalo/plush.BuffaloRenderer instead.
 func JSTemplateEngine(input string, data map[string]interface{}, helpers map[string]interface{}) (string, error) {
-	var pf partFunc
-	var ok bool
-	if pf, ok = helpers["partial"].(func(string, Data) (template.HTML, error)); !ok {
-		return "", errors.New("could not find a partial function")
-	}
-
-	helpers["partial"] = func(name string, dd Data) (template.HTML, error) {
-		if strings.Contains(name, ".js") {
-			return pf(name, dd)
-		}
-		h, err := pf(name, dd)
-		if err != nil {
-			return "", errors.WithStack(err)
-		}
-		he := template.JSEscapeString(string(h))
-		return template.HTML(he), nil
-	}
-
+	oncer.Deprecate(0, "render.JSTemplateEngine", "Use github.com/gobuffalo/plush.BuffaloRenderer instead.")
 	return plush.BuffaloRenderer(input, data, helpers)
 }
-
-type partFunc func(string, Data) (template.HTML, error)

--- a/render/partials_test.go
+++ b/render/partials_test.go
@@ -75,6 +75,60 @@ func Test_Template_Partial_Form(t *testing.T) {
 
 }
 
+func Test_Template_Partial_With_For(t *testing.T) {
+	r := require.New(t)
+
+	const forHTML = `<%= for(user) in users { %><%= partial("row") %><% } %>`
+	const rowHTML = `Hi <%= user.Name %>, `
+	const result = `Hi Mark, Hi Yonghwan,`
+
+	users := []struct {
+		Name string
+	}{{Name: "Mark"}, {Name: "Yonghwan"}}
+
+	err := withHTMLFile("for.html", forHTML, func(e *Engine) {
+		err := withHTMLFile("_row.html", rowHTML, func(e *Engine) {
+
+			re := e.Template("text/html; charset=utf-8", "for.html")
+			bb := &bytes.Buffer{}
+			err := re.Render(bb, Data{"users": users})
+			r.NoError(err)
+			r.Equal(result, strings.TrimSpace(bb.String()))
+
+		})
+		r.NoError(err)
+	})
+	r.NoError(err)
+
+}
+
+func Test_Template_Partial_With_For_And_Local(t *testing.T) {
+	r := require.New(t)
+
+	const forHTML = `<%= for(user) in users { %><%= partial("row", {say:"Hi"}) %><% } %>`
+	const rowHTML = `<%= say %> <%= user.Name %>, `
+	const result = `Hi Mark, Hi Yonghwan,`
+
+	users := []struct {
+		Name string
+	}{{Name: "Mark"}, {Name: "Yonghwan"}}
+
+	err := withHTMLFile("for.html", forHTML, func(e *Engine) {
+		err := withHTMLFile("_row.html", rowHTML, func(e *Engine) {
+
+			re := e.Template("text/html; charset=utf-8", "for.html")
+			bb := &bytes.Buffer{}
+			err := re.Render(bb, Data{"users": users})
+			r.NoError(err)
+			r.Equal(result, strings.TrimSpace(bb.String()))
+
+		})
+		r.NoError(err)
+	})
+	r.NoError(err)
+
+}
+
 func Test_Template_Partial_Recursive_With_Global_And_Local_Context(t *testing.T) {
 	r := require.New(t)
 

--- a/render/render.go
+++ b/render/render.go
@@ -32,7 +32,7 @@ func New(opts Options) *Engine {
 		opts.TemplateEngines["txt"] = plush.BuffaloRenderer
 	}
 	if _, ok := opts.TemplateEngines["js"]; !ok {
-		opts.TemplateEngines["js"] = JSTemplateEngine
+		opts.TemplateEngines["js"] = plush.BuffaloRenderer
 	}
 	if _, ok := opts.TemplateEngines["md"]; !ok {
 		opts.TemplateEngines["md"] = MDTemplateEngine

--- a/render/template.go
+++ b/render/template.go
@@ -1,7 +1,6 @@
 package render
 
 import (
-	"fmt"
 	"html/template"
 	"io"
 	"os"
@@ -17,7 +16,6 @@ type templateRenderer struct {
 	*Engine
 	contentType string
 	names       []string
-	data        Data
 }
 
 func (s templateRenderer) ContentType() string {
@@ -25,7 +23,6 @@ func (s templateRenderer) ContentType() string {
 }
 
 func (s *templateRenderer) Render(w io.Writer, data Data) error {
-	s.data = data
 	var body template.HTML
 	var err error
 	for _, name := range s.names {
@@ -39,39 +36,7 @@ func (s *templateRenderer) Render(w io.Writer, data Data) error {
 	return nil
 }
 
-func (s templateRenderer) partial(name string, dd Data) (template.HTML, error) {
-	d, f := filepath.Split(name)
-	name = filepath.Join(d, "_"+f)
-	m := Data{}
-	for k, v := range s.data {
-		m[k] = v
-	}
-	for k, v := range dd {
-		m[k] = v
-	}
-
-	if _, ok := m["layout"]; ok {
-
-		var body template.HTML
-		var err error
-
-		body, err = s.exec(name, m)
-		if err != nil {
-			return body, err
-		}
-		m["yield"] = body
-		d, f := filepath.Split(fmt.Sprintf("%v", m["layout"]))
-		name = filepath.Join(d, "_"+f)
-
-	}
-
-	return s.exec(name, m)
-}
-
-func (s templateRenderer) exec(name string, data Data) (template.HTML, error) {
-	ct := strings.ToLower(s.contentType)
-	data["contentType"] = ct
-
+func fixExtension(name string, ct string) string {
 	if filepath.Ext(name) == "" {
 		switch {
 		case strings.Contains(ct, "html"):
@@ -82,6 +47,27 @@ func (s templateRenderer) exec(name string, data Data) (template.HTML, error) {
 			name += ".md"
 		}
 	}
+	return name
+}
+
+// partialFeeder returns template string for the name from `TemplateBox`.
+// It should be registered as helper named `partialFeeder` so plush can
+// find it with the name.
+func (s templateRenderer) partialFeeder(name string) (string, error) {
+	ct := strings.ToLower(s.contentType)
+
+	d, f := filepath.Split(name)
+	name = filepath.Join(d, "_"+f)
+	name = fixExtension(name, ct)
+
+	return s.TemplatesBox.FindString(name)
+}
+
+func (s templateRenderer) exec(name string, data Data) (template.HTML, error) {
+	ct := strings.ToLower(s.contentType)
+	data["contentType"] = ct
+
+	name = fixExtension(name, ct)
 
 	// Try to use localized version
 	templateName := name
@@ -119,7 +105,7 @@ func (s templateRenderer) exec(name string, data Data) (template.HTML, error) {
 	}
 
 	helpers := map[string]interface{}{
-		"partial": s.partial,
+		"partialFeeder": s.partialFeeder,
 	}
 
 	helpers = s.addAssetsHelpers(helpers)


### PR DESCRIPTION
Hi, @markbates and all,

Added a test case for issue #1406. I think the solution to this issue should be in `plush` and I tested with patch below:

```diff
--- a/compiler.go
+++ b/compiler.go
@@ -504,6 +504,21 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
                                return nil, errors.WithStack(err)
                        }
 
+                       // 3. if the function is `partial` and user provides second argument,
+                       //    merge it with current context's data which has loop var.
+                       if node.Function.String() == "partial" && pos == 1 {
+                               fmt.Printf("XXX - %T, %v\n", v, v)
+                               data := map[string]interface{}{}
+                               for k, vv := range c.ctx.data {
+                                       data[k] = vv
+                               }
+                               for k, vv := range v.(map[string]interface{}) {
+                                       data[k] = vv
+                               }
+                               v = data
+                               fmt.Printf("XXX - %T, %v\n", v, v)
+                       }
+
                        var ar reflect.Value
                        expectedT := rt.In(pos)
                        if v != nil {
@@ -520,6 +535,12 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
                        args = append(args, ar)
                }
 
+               // 3.1. if the function is `partial` but there is no second argument,
+               //      just use current context's data as second argument.
+               if node.Function.String() == "partial" && len(node.Arguments) == 1 {
+                       args = append(args, reflect.ValueOf(c.ctx.data))
+               }
+
                hc := func(arg reflect.Type) {
                        if arg.ConvertibleTo(reflect.TypeOf(HelperContext{})) {
                                hargs := HelperContext{
@@ -619,6 +640,7 @@ func (c *compiler) evalCallExpression(node *ast.CallExpression) (interface{}, er
                }
        }
 
+       // 4. finally it calls `partial()` but it runs on another context.
        res := rv.Call(args)
        if len(res) > 0 {
                if e, ok := res[len(res)-1].Interface().(error); ok {
@@ -634,6 +656,8 @@ func (c *compiler) evalForExpression(node *ast.ForExpression) (interface{}, erro
        defer func() {
                c.ctx = octx
        }()
+       // 1. create new context for `for` block here.
+       //    anyway this context does not have values form original.
        c.ctx = octx.New()
        iter, err := c.evalExpression(node.Iterable)
        if err != nil {
@@ -661,8 +685,9 @@ func (c *compiler) evalForExpression(node *ast.ForExpression) (interface{}, erro
        case reflect.Slice, reflect.Array:
                for i := 0; i < riter.Len(); i++ {
                        v := riter.Index(i)
-                       c.ctx.Set(node.KeyName, i)
+                       c.ctx.Set(node.KeyName, i) // misc: is it required?
                        c.ctx.Set(node.ValueName, v.Interface())
+                       // 2. it calls evalBlockStatement after set new values
                        res, err := c.evalBlockStatement(node.Block)
                        if err != nil {
                                return nil, errors.WithStack(err)
```