### PR TITLE
Reset content-type to html for detailed error page

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -175,6 +175,7 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 			return errors.WithStack(err)
 		}
 	default:
+		c.Response().Header().Set("content-type", "text/html; charset=utf-8")
 		if err := c.Request().ParseForm(); err != nil {
 			trace = fmt.Sprintf("%s\n%s", err.Error(), trace)
 		}


### PR DESCRIPTION
(This is a rebase of PR #1434 against master)

This PR resolves a bug with the default development error handler where it will reflect the Request Content-Type. If a form handler triggers an error in development mode, the response Content-Type will be set to "application/x-www-form-urlencoded", which is wrong and causes the browser to display an error. The code responsible for this is `defaultErrorHandler()` in errorrs.go:

```
func defaultErrorHandler(status int, origErr error, c Context) error {
	env := c.Value("env")
	ct := defaults.String(httpx.ContentType(c.Request()), "text/html; charset=utf-8")
```

Prior to this fix, calling return c.Error(404, err) within a POST/PUT handler resulted in the following response:
```
< HTTP/1.1 404 Not Found
< Content-Type: application/x-www-form-urlencoded
< Date: Thu, 01 Nov 2018 21:46:15 GMT
< Transfer-Encoding: chunked
<
<html>
<head>
  <title>404 - ERROR!</title>
```
After this fix, the Content-Type is correctly set to: text/html; charset=utf-8 and the error page renders correctly within the browser.