### PR TITLE
Add utf-8 charset to xml and json content type

### DIFF
--- a/render/json.go
+++ b/render/json.go
@@ -10,7 +10,7 @@ type jsonRenderer struct {
 }
 
 func (s jsonRenderer) ContentType() string {
-	return "application/json"
+	return "application/json; charset=utf-8"
 }
 
 func (s jsonRenderer) Render(w io.Writer, data Data) error {

--- a/render/json_test.go
+++ b/render/json_test.go
@@ -21,7 +21,7 @@ func Test_JSON(t *testing.T) {
 
 	for _, j := range table {
 		re := j(map[string]string{"hello": "world"})
-		r.Equal("application/json", re.ContentType())
+		r.Equal("application/json; charset=utf-8", re.ContentType())
 		bb := &bytes.Buffer{}
 		err := re.Render(bb, nil)
 		r.NoError(err)

--- a/render/xml.go
+++ b/render/xml.go
@@ -10,7 +10,7 @@ type xmlRenderer struct {
 }
 
 func (s xmlRenderer) ContentType() string {
-	return "application/xml"
+	return "application/xml; charset=utf-8"
 }
 
 func (s xmlRenderer) Render(w io.Writer, data Data) error {

--- a/render/xml_test.go
+++ b/render/xml_test.go
@@ -25,7 +25,7 @@ func Test_XML(t *testing.T) {
 
 	for _, j := range table {
 		re := j(user{Name: "mark"})
-		r.Equal("application/xml", re.ContentType())
+		r.Equal("application/xml; charset=utf-8", re.ContentType())
 		bb := &bytes.Buffer{}
 		err := re.Render(bb, nil)
 		r.NoError(err)


### PR DESCRIPTION
This should prevent some kinds of json hijacking for older browsers and Microsoft Edge (which seems to still be vulnerable to every single poc): https://portswigger.net/blog/json-hijacking-for-the-modern-web

For xml, this shouldn't really make any difference, I just thought it was more consistent to change it as well.