### PR TITLE
Fix panic in buffalo info

### DIFF
--- a/buffalo/cmd/info.go
+++ b/buffalo/cmd/info.go
@@ -31,6 +31,9 @@ var infoCmd = &cobra.Command{
 		var err error
 		for i := 0; i < rt.NumField(); i++ {
 			f := rt.Field(i)
+			if !rv.FieldByName(f.Name).CanInterface() {
+				continue
+			}
 			_, err = bb.WriteString(fmt.Sprintf("%s=%v\n", f.Name, rv.FieldByName(f.Name).Interface()))
 			if err != nil {
 				return err


### PR DESCRIPTION
https://github.com/gobuffalo/meta/commit/0d7e59dd540b2ef77f8dd051c596c8b6f8c660f9 introduced an unexported field to [gobuffalo/meta/app.go](https://github.com/gobuffalo/meta/blob/0d7e59dd540b2ef77f8dd051c596c8b6f8c660f9/app.go#L44), causing a panic in `buffalo info`.

This commit will change the behaviour to ignore inaccessible fields.