### PR TITLE
Correct content-type on error for form submissions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -142,8 +142,9 @@ type ErrorResponse struct {
 
 func defaultErrorHandler(status int, origErr error, c Context) error {
 	env := c.Value("env")
-	ct := defaults.String(httpx.ContentType(c.Request()), "text/html; charset=utf-8")
-	c.Response().Header().Set("content-type", ct)
+
+	c.Response().Header().Set("content-type", "text/html; charset=utf-8")
+	rct := defaults.String(httpx.ContentType(c.Request()), "text/html; charset=utf-8")
 
 	c.Logger().Error(origErr)
 	c.Response().WriteHeader(status)
@@ -155,8 +156,9 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 	}
 
 	trace := fmt.Sprintf("%+v", origErr)
-	switch strings.ToLower(ct) {
+	switch strings.ToLower(rct) {
 	case "application/json", "text/json", "json":
+		c.Response().Header().Set("content-type", rct)
 		err := json.NewEncoder(c.Response()).Encode(&ErrorResponse{
 			Error: errors.Cause(origErr).Error(),
 			Trace: trace,
@@ -166,6 +168,7 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 			return errors.WithStack(err)
 		}
 	case "application/xml", "text/xml", "xml":
+		c.Response().Header().Set("content-type", rct)
 		err := xml.NewEncoder(c.Response()).Encode(&ErrorResponse{
 			Error: errors.Cause(origErr).Error(),
 			Trace: trace,
@@ -175,7 +178,6 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 			return errors.WithStack(err)
 		}
 	default:
-		c.Response().Header().Set("content-type", "text/html; charset=utf-8")
 		if err := c.Request().ParseForm(); err != nil {
 			trace = fmt.Sprintf("%s\n%s", err.Error(), trace)
 		}


### PR DESCRIPTION
This PR is a rework of #1436, which tried to solve the issue where the error handler would reflect the client Content-Type, leading to a browser error. The new patch defaults output to `text/html` and only overrides this in the xml and json handlers. Testing this requires returning an error from a handler that processes a form request.