### PR TITLE
removes the -no-sqlite from the released binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
   env:
     - CGO_ENABLED=0
   main: ./buffalo/main.go
-  binary: buffalo-no-sqlite
+  binary: buffalo
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml.plush
+++ b/.goreleaser.yml.plush
@@ -7,7 +7,7 @@ builds:
   env:
     - CGO_ENABLED=0
   main: ./buffalo/main.go
-  binary: buffalo-no-sqlite
+  binary: buffalo
 
 checksum:
   name_template: 'checksums.txt'
@@ -30,8 +30,8 @@ brew:
   homepage: https://gobuffalo.io
   description: A Go web development eco-system, designed to make your life easier.
   install: |
-    bin.install "buffalo-no-sqlite"
-    mv "#{bin}/buffalo-no-sqlite", "#{bin}/buffalo"
+    bin.install "buffalo"
+    mv "#{bin}/buffalo", "#{bin}/buffalo"
   test: |
     system "#{bin}/buffalo", "version"
 <% } %>

--- a/.goreleaser.yml.plush
+++ b/.goreleaser.yml.plush
@@ -31,7 +31,6 @@ brew:
   description: A Go web development eco-system, designed to make your life easier.
   install: |
     bin.install "buffalo"
-    mv "#{bin}/buffalo", "#{bin}/buffalo"
   test: |
     system "#{bin}/buffalo", "version"
 <% } %>


### PR DESCRIPTION
It seems odd to name the released binaries `buffalo-no-sqlite` when there isn't a `buffalo-with-sqlite`. Also, since sqlite support is opt-in it should be `buffalo` without sqlite and `buffalo-with-sqlite`, if we ever decide to do that.