### PR TITLE
Overriding app.ErrorMiddleware has no effect fixes #1466

### DIFF
--- a/app.go
+++ b/app.go
@@ -16,15 +16,14 @@ import (
 type App struct {
 	Options
 	// Middleware returns the current MiddlewareStack for the App/Group.
-	Middleware      *MiddlewareStack `json:"-"`
-	ErrorHandlers   ErrorHandlers    `json:"-"`
-	ErrorMiddleware MiddlewareFunc   `json:"-"`
-	router          *mux.Router
-	moot            *sync.RWMutex
-	routes          RouteList
-	root            *App
-	children        []*App
-	filepaths       []string
+	Middleware    *MiddlewareStack `json:"-"`
+	ErrorHandlers ErrorHandlers    `json:"-"`
+	router        *mux.Router
+	moot          *sync.RWMutex
+	routes        RouteList
+	root          *App
+	children      []*App
+	filepaths     []string
 }
 
 // Muxer returns the underlying mux router to allow
@@ -52,9 +51,6 @@ func New(opts Options) *App {
 	}
 
 	dem := a.defaultErrorMiddleware
-	if a.ErrorMiddleware != nil {
-		dem = a.ErrorMiddleware
-	}
 	a.Middleware = newMiddlewareStack(dem)
 
 	notFoundHandler := func(errorf string, code int) http.HandlerFunc {
@@ -76,4 +72,10 @@ func New(opts Options) *App {
 	a.Use(sessionSaver)
 
 	return a
+}
+
+// UseErrorMiddleware will set the error middleware.
+// This will OVERRIDE the use of the ErrorHandlers.
+func (a *App) UseErrorMiddleware(e MiddlewareFunc) {
+	a.Middleware.Replace(a.defaultErrorMiddleware, e)
 }

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
-	golang.org/x/tools v0.0.0-20190201185910-0e05534988fe
+	golang.org/x/tools v0.0.0-20190202235157-7414d4c1f71c
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc
 )

--- a/go.sum
+++ b/go.sum
@@ -583,8 +583,8 @@ golang.org/x/tools v0.0.0-20190118193359-16909d206f00/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190122202912-9c309ee22fab/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190124004107-78ee07aa9465/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190131142011-8dbcc66f33bb/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190201185910-0e05534988fe h1:vnIBlz9Fwms9Qgql2K0Ar+XatQxNe3xuRwzm4XtKZJ8=
-golang.org/x/tools v0.0.0-20190201185910-0e05534988fe/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190202235157-7414d4c1f71c h1:6Axm8Kqba7gHaI7My7snFynbKaVEYko0z35GPOJygUA=
+golang.org/x/tools v0.0.0-20190202235157-7414d4c1f71c/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=

--- a/route_info.go
+++ b/route_info.go
@@ -109,10 +109,14 @@ func (ri RouteInfo) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	err := a.Middleware.handler(ri)(c)
 
 	if err != nil {
+		status := 500
+		if he, ok := err.(HTTPError); ok {
+			status = he.Status
+		}
 		events.EmitError(EvtRouteErr, err, payload)
 		// things have really hit the fan if we're here!!
 		a.Logger.Error(err)
-		c.Response().WriteHeader(500)
+		c.Response().WriteHeader(status)
 		c.Response().Write([]byte(err.Error()))
 	}
 	events.EmitPayload(EvtRouteFinished, payload)


### PR DESCRIPTION
This is a breaking change. We have to replace `app.ErrorMiddleware` with a function, `app.UseErrorMiddleware`. As discussed in #1466 the current `app.ErrorMiddleware` field doesn't have any effect. The reason for this is that the `MiddlewareStack` for the application isn't being updated to replace the original `defaultErrorMiddleware` the app was created with.

This PR adds a new function `app.UseErrorMiddleware` that will update the middleware stack accordingly. It also removes, `app.ErrorMiddleware`, which is a breaking change. 

Seeing as how `app.ErrorMiddleware` has never actually worked, I don't see this affecting too many people.