### PR TITLE
Make ErrorHandler more robust #1466

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,7 +17,7 @@ type App struct {
 	Options
 	// Middleware returns the current MiddlewareStack for the App/Group.
 	Middleware    *MiddlewareStack `json:"-"`
-	ErrorHandlers ErrorHandlers    `json:"-"`
+	ErrorHandlers *ErrorHandlersST `json:"-"`
 	router        *mux.Router
 	moot          *sync.RWMutex
 	routes        RouteList
@@ -39,16 +39,17 @@ func New(opts Options) *App {
 	opts = optionsWithDefaults(opts)
 
 	a := &App{
-		Options: opts,
-		ErrorHandlers: ErrorHandlers{
-			404: defaultErrorHandler,
-			500: defaultErrorHandler,
-		},
-		router:   mux.NewRouter(),
-		moot:     &sync.RWMutex{},
-		routes:   RouteList{},
-		children: []*App{},
+		Options:       opts,
+		ErrorHandlers: &ErrorHandlersST{},
+		router:        mux.NewRouter(),
+		moot:          &sync.RWMutex{},
+		routes:        RouteList{},
+		children:      []*App{},
 	}
+	a.ErrorHandlers.SetMulti(ErrorHandlers{
+		404: DefaultErrorHandler,
+		500: DefaultErrorHandler,
+	})
 
 	dem := a.defaultErrorMiddleware
 	a.Middleware = newMiddlewareStack(dem)

--- a/not_found_test.go
+++ b/not_found_test.go
@@ -45,11 +45,11 @@ func Test_App_Override_NotFound(t *testing.T) {
 	r := require.New(t)
 
 	a := New(Options{})
-	a.ErrorHandlers[404] = func(status int, err error, c Context) error {
+	a.ErrorHandlers.Set(404, func(status int, err error, c Context) error {
 		c.Response().WriteHeader(404)
 		c.Response().Write([]byte("oops!!!"))
 		return nil
-	}
+	})
 	a.GET("/foo", func(c Context) error { return nil })
 
 	w := httptest.New(a)

--- a/route_mappings.go
+++ b/route_mappings.go
@@ -204,7 +204,7 @@ func (a *App) Group(groupPath string) *App {
 
 	g.router = a.router
 	g.Middleware = a.Middleware.clone()
-	g.ErrorHandlers = a.ErrorHandlers
+	g.ErrorHandlers = a.ErrorHandlers.Clone()
 	g.root = a
 	if a.root != nil {
 		g.root = a.root

--- a/router_test.go
+++ b/router_test.go
@@ -39,12 +39,12 @@ func testApp() *App {
 	rt.OPTIONS("/", h)
 	rt.PATCH("/", h)
 
-	a.ErrorHandlers[405] = func(status int, err error, c Context) error {
+	a.ErrorHandlers.Set(405, func(status int, err error, c Context) error {
 		res := c.Response()
 		res.WriteHeader(status)
 		res.Write([]byte("my custom 405"))
 		return nil
-	}
+	})
 	return a
 }
 
@@ -67,12 +67,12 @@ func Test_MethodNotFoundError(t *testing.T) {
 	a.GET("/bar", func(c Context) error {
 		return c.Render(200, render.String("bar"))
 	})
-	a.ErrorHandlers[405] = func(status int, err error, c Context) error {
+	a.ErrorHandlers.Set(405, func(status int, err error, c Context) error {
 		res := c.Response()
 		res.WriteHeader(status)
 		res.Write([]byte("my custom 405"))
 		return nil
-	}
+	})
 	w := httptest.New(a)
 	res := w.HTML("/bar").Post(nil)
 	r.Equal(405, res.Code)


### PR DESCRIPTION
Don't expose internal ErrorHandlers map and declare Get/Set methods to manage registered ErrorHandlers.

- make ErrorHandlers Get function more robust (handle nil)
- introduce Clear, Clone, Set and SetMulti functions
- export DefaultErrorHandler function so that user can call it from its
  handler if needed be
- add a new test to check Clear and SetMulti functions