### PR TITLE
Use a sane Etag value vs stringfied Time

### DIFF
--- a/route_mappings.go
+++ b/route_mappings.go
@@ -110,7 +110,7 @@ func (a *App) fileServer(fs http.FileSystem) http.Handler {
 
 		stat, _ := f.Stat()
 		maxAge := envy.Get(AssetsAgeVarName, "31536000")
-		w.Header().Add("ETag", fmt.Sprintf("%x", stat.ModTime()))
+		w.Header().Add("ETag", fmt.Sprintf("%x", stat.ModTime().UnixNano()))
 		w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%s", maxAge))
 		fsh.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
This corrects the ETag format from `Etag: 323031392d30322d32352031363a32353a30362e333635333234343735202b3030303020555443206d3d2b313039392e373332333238373232` to the more sane `Etag: 1174efedab186000`
