### PR TITLE
Loosen dependency on pop

### DIFF
--- a/binding/binding.go
+++ b/binding/binding.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gobuffalo/pop/nulls"
+	"github.com/gobuffalo/nulls"
 	"github.com/gobuffalo/x/httpx"
 	"github.com/monoculum/formam"
 	"github.com/pkg/errors"

--- a/default_context.go
+++ b/default_context.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gobuffalo/buffalo/binding"
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/pop"
 	"github.com/pkg/errors"
 )
 
@@ -101,6 +100,10 @@ func (d *DefaultContext) Flash() *Flash {
 	return d.flash
 }
 
+type paginable interface {
+	Paginate() string
+}
+
 // Render a status code and render.Renderer to the associated Response.
 // The request parameters will be made available to the render.Renderer
 // "{{.params}}". Any values set onto the Context will also automatically
@@ -138,8 +141,8 @@ func (d *DefaultContext) Render(status int, rr render.Renderer) error {
 		}
 
 		d.Response().Header().Set("Content-Type", rr.ContentType())
-		if p, ok := data["pagination"].(*pop.Paginator); ok {
-			d.Response().Header().Set("X-Pagination", p.String())
+		if p, ok := data["pagination"].(paginable); ok {
+			d.Response().Header().Set("X-Pagination", p.Paginate())
 		}
 		d.Response().WriteHeader(status)
 		_, err = io.Copy(d.Response(), bb)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gobuffalo/httptest v1.1.0
 	github.com/gobuffalo/logger v0.0.0-20190224201004-be78ebfea0fa
 	github.com/gobuffalo/meta v0.0.0-20190207205153-50a99e08b8cf
-	github.com/gobuffalo/nulls v0.0.0-20190305142546-85f3c9250d87 // indirect
+	github.com/gobuffalo/nulls v0.0.0-20190305142546-85f3c9250d87
 	github.com/gobuffalo/packd v0.0.0-20190224160250-d04dd98aca5b
 	github.com/gobuffalo/packr v1.22.0
 	github.com/gobuffalo/packr/v2 v2.0.3


### PR DESCRIPTION
* Use paginable interface instead of pop.Paginator.
* Migrate pop/nulls to gobuffalo/nulls.