### PR TITLE
Fix skip build deps on cleanup

### DIFF
--- a/genny/build/cleanup.go
+++ b/genny/build/cleanup.go
@@ -36,7 +36,7 @@ func Cleanup(opts *Options) genny.RunFn {
 				return err
 			}
 		}
-		if envy.Mods() {
+		if envy.Mods() && opts.WithBuildDeps {
 			if err := r.Exec(exec.Command(genny.GoBin(), "mod", "tidy")); err != nil {
 				return err
 			}

--- a/genny/build/cleanup_test.go
+++ b/genny/build/cleanup_test.go
@@ -1,0 +1,64 @@
+package build
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gobuffalo/envy"
+	"github.com/gobuffalo/genny/gentest"
+	"github.com/gobuffalo/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_WithDeps(t *testing.T) {
+	r := require.New(t)
+	envy.Set(envy.GO111MODULE, "on")
+
+	run := gentest.NewRunner()
+
+	opts := &Options{
+		WithAssets:    false,
+		WithBuildDeps: true,
+		Environment:   "bar",
+		App:           meta.New("."),
+	}
+
+	emptyMap := sync.Map{}
+	opts.rollback = &emptyMap
+
+	f := Cleanup(opts)
+	f(run)
+
+	results := run.Results()
+
+	cmds := []string{"go mod tidy"}
+	for i, c := range results.Commands {
+		fmt.Println(fmt.Sprintf("c: %v", c))
+		eq(r, cmds[i], c)
+	}
+}
+
+func Test_WithoutDeps(t *testing.T) {
+	r := require.New(t)
+	envy.Set(envy.GO111MODULE, "on")
+
+	run := gentest.NewRunner()
+
+	opts := &Options{
+		WithAssets:    false,
+		WithBuildDeps: false,
+		Environment:   "bar",
+		App:           meta.New("."),
+	}
+
+	emptyMap := sync.Map{}
+	opts.rollback = &emptyMap
+
+	f := Cleanup(opts)
+	f(run)
+
+	results := run.Results()
+
+	r.Len(results.Commands, 0)
+}

--- a/genny/build/cleanup_test.go
+++ b/genny/build/cleanup_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 
@@ -34,7 +33,6 @@ func Test_WithDeps(t *testing.T) {
 
 	cmds := []string{"go mod tidy"}
 	for i, c := range results.Commands {
-		fmt.Println(fmt.Sprintf("c: %v", c))
 		eq(r, cmds[i], c)
 	}
 }


### PR DESCRIPTION
Cleanup was calling `go mod tidy` which started to update existing modules even though I though it is only for cleaning up unused things.