### PR TITLE
Add ARM builds for buffalo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,14 @@ builds:
     - darwin
     - linux
     - windows
+  goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+  goarm:
+    - 6
+    - 7
   env:
     - CGO_ENABLED=0
   main: ./buffalo/main.go

--- a/.goreleaser.yml.plush
+++ b/.goreleaser.yml.plush
@@ -4,6 +4,14 @@ builds:
     - darwin
     - linux
     - windows
+  goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+  goarm:
+    - 6
+    - 7
   env:
     - CGO_ENABLED=0
   main: ./buffalo/main.go


### PR DESCRIPTION
Configure Goreleaser to build for Linux ARM targets.

Fixes #1713.