### PR TITLE
Task fixing slim dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gobuffalo/buffalo:latest
+ENV GOPROXY=https://proxy.golang.org
 
 ARG CODECOV_TOKEN
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,8 @@
 FROM golang:latest
 EXPOSE 3000
 ENV BP=$GOPATH/src/github.com/gobuffalo/buffalo
+ENV GOPROXY=https://proxy.golang.org
+
 RUN go version
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash \

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -34,12 +34,9 @@ RUN rm -rfv $BP && mkdir -p $BP
 WORKDIR $BP
 
 COPY . .
-ENV GO111MODULE=on 
-ENV GOPROXY=https://proxy.golang.org 
+ENV GO111MODULE=on GOPROXY=https://proxy.golang.org 
 RUN make deps && make install
-
-ENV GO111MODULE=auto
-ENV GOPROXY=
+ENV GO111MODULE=auto GOPROXY=
 
 RUN buffalo version
 

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -34,7 +34,12 @@ RUN rm -rfv $BP && mkdir -p $BP
 WORKDIR $BP
 
 COPY . .
+ENV GO111MODULE=on 
+ENV GOPROXY=https://proxy.golang.org 
 RUN make deps && make install
+
+ENV GO111MODULE=auto
+ENV GOPROXY=
 
 RUN buffalo version
 

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -1,6 +1,8 @@
 FROM golang:alpine
 EXPOSE 3000
 ENV BP=$GOPATH/src/github.com/gobuffalo/buffalo
+ENV GOPROXY=https://proxy.golang.org 
+
 RUN apk add --no-cache --upgrade apk-tools \
 && apk add --no-cache bash curl openssl git build-base nodejs npm postgresql libpq postgresql-contrib sqlite sqlite-dev mysql-client vim
 
@@ -34,9 +36,9 @@ RUN rm -rfv $BP && mkdir -p $BP
 WORKDIR $BP
 
 COPY . .
-ENV GO111MODULE=on GOPROXY=https://proxy.golang.org 
+ENV GO111MODULE=on
 RUN make deps && make install
-ENV GO111MODULE=auto GOPROXY=
+ENV GO111MODULE=
 
 RUN buffalo version
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
 variables:
   GOBIN:  "$(GOPATH)/bin" # Go binaries path
   GOPATH: "$(system.defaultWorkingDirectory)/gopath" # Go workspace path
+  GOPROXY: "https://proxy.golang.org"
   modulePath: "$(GOPATH)/src/github.com/$(build.repository.name)" # Path to the module"s code
 
 jobs:


### PR DESCRIPTION
@gobuffalo/core-managers This PR fixes our Dockerfile.slim.build file which seems to be broken at this point, it also uses the official go proxy which both speeds our builds and make these slimmer.