### PR TITLE
Cookie.Secure only for production

### DIFF
--- a/options.go
+++ b/options.go
@@ -162,9 +162,12 @@ func optionsWithDefaults(opts Options) Options {
 		}
 
 		cookieStore := sessions.NewCookieStore([]byte(secret))
+
 		//Cookie secure attributes, see: https://www.owasp.org/index.php/Testing_for_cookies_attributes_(OTG-SESS-002)
 		cookieStore.Options.HttpOnly = true
-		cookieStore.Options.Secure = true
+		if opts.Env == "production" {
+			cookieStore.Options.Secure = true
+		}
 
 		opts.SessionStore = cookieStore
 	}


### PR DESCRIPTION
As discussed in #1843 Secure attribute is causing issues in development. This PR changes it to be used only in production.