### PR TITLE
Fix status code & duplicates bug in logs

### DIFF
--- a/default_context.go
+++ b/default_context.go
@@ -175,6 +175,12 @@ func (d *DefaultContext) LogFields(values map[string]interface{}) {
 }
 
 func (d *DefaultContext) Error(status int, err error) error {
+	d.LogField("error", err.Error())
+	ws, ok := d.Response().(*Response)
+	if !ok {
+		ws = &Response{ResponseWriter: d.Response()}
+	}
+	ws.Status = status
 	return HTTPError{Status: status, Cause: err}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -159,7 +159,6 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 	env := c.Value("env")
 	requestCT := defaults.String(httpx.ContentType(c.Request()), defaultErrorCT)
 
-	c.Logger().Error(origErr)
 	c.Response().WriteHeader(status)
 
 	if env != nil && env.(string) == "production" {

--- a/request_logger.go
+++ b/request_logger.go
@@ -69,7 +69,13 @@ func RequestLoggerFunc(h Handler) Handler {
 				"human_size": humanize.Bytes(uint64(ws.Size)),
 				"status":     ws.Status,
 			})
-			c.Logger().Info(req.URL.String())
+			// Log with level according to status code
+			switch status := ws.Status; {
+			case status >= http.StatusInternalServerError:
+				c.Logger().Error(req.URL.String())
+			default:
+				c.Logger().Info(req.URL.String())
+			}
 		}()
 		return h(c)
 	}


### PR DESCRIPTION
This PR attempts to fix 2 bugs in the logs:
- the status code is missing in the logs when calling `c.Error()` (as describe in the issue #1171 )
- When calling `c.Error()`, two similar logs are produced : 1 that comes from the `request_logger`, 1 from the `defaultErrorHandler`

**Proposal**
- In `c.Error()`: set the `response.Status` used in logs, and add the error message in a logfield `error`
- Only write the logs in request_logger, and set the log level according to the status code 