### PR TITLE
Remove Intermediate files

### DIFF
--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -214,6 +214,9 @@ var newCmd = &cobra.Command{
 		}
 
 		if err := run.Run(); err != nil {
+			if err := os.RemoveAll(app.Root); err == nil {
+				run.Logger.Debugf("Succussfully removed all intermediate files due to error")
+			}
 			return err
 		}
 


### PR DESCRIPTION
This PR aims to remove all the files left over when `buffalo new <app-name>` results in an error.
So incase of any error I am removing the folder itself to remove junk files