### PR TITLE
Fix greedy forbidden names

### DIFF
--- a/genny/newapp/core/options.go
+++ b/genny/newapp/core/options.go
@@ -75,11 +75,7 @@ func (opts *Options) Validate() error {
 	name := strings.ToLower(opts.App.Name.String())
 	fb := append(opts.ForbiddenNames, "buffalo", "test", "dev")
 	for _, n := range fb {
-		rx, err := regexp.Compile(n)
-		if err != nil {
-			return err
-		}
-		if rx.MatchString(name) {
+		if n == name {
 			return fmt.Errorf("name %s is not allowed, try a different application name", opts.App.Name)
 		}
 	}

--- a/genny/newapp/core/options_test.go
+++ b/genny/newapp/core/options_test.go
@@ -33,4 +33,11 @@ func Test_Options_Validate(t *testing.T) {
 	err = opts.Validate()
 	r.NoError(err)
 
+	opts.App.Name = name.New("test")
+	err = opts.Validate()
+	r.Error(err)
+
+	opts.App.Name = name.New("testapp")
+	err = opts.Validate()
+	r.NoError(err)
 }


### PR DESCRIPTION
testapp should be a valid name, but because of the regex matching it was not allowed.