### PR TITLE
Removing last GOPATH elements from Dockerfile

### DIFF
--- a/genny/docker/templates/multi/Dockerfile.tmpl
+++ b/genny/docker/templates/multi/Dockerfile.tmpl
@@ -2,8 +2,11 @@
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 FROM gobuffalo/buffalo:{{.opts.Version}} as builder
 
-RUN mkdir -p $GOPATH/src/{{.opts.App.PackagePkg}}
-WORKDIR $GOPATH/src/{{.opts.App.PackagePkg}}
+ENV GO111MODULE on
+ENV GOPROXY https://proxy.golang.org
+
+RUN mkdir -p /{{.opts.App.PackagePkg}}
+WORKDIR /{{.opts.App.PackagePkg}}
 
 {{if .opts.App.WithWebpack -}}
 # this will cache the npm install step, unless package.json changes
@@ -17,10 +20,6 @@ RUN npm install --no-progress
 {{end -}}
 
 ADD . .
-{{if .opts.App.WithModules -}}
-ENV GO111MODULE=on
-{{end -}}
-RUN go get ./...
 RUN buffalo build --static -o /bin/app
 
 FROM alpine

--- a/genny/docker/templates/standard/Dockerfile.tmpl
+++ b/genny/docker/templates/standard/Dockerfile.tmpl
@@ -1,7 +1,10 @@
 FROM gobuffalo/buffalo:{{.opts.Version}}
 
-RUN mkdir -p $GOPATH/src/{{.opts.App.PackagePkg}}
-WORKDIR $GOPATH/src/{{.opts.App.PackagePkg}}
+ENV GO111MODULE on
+ENV GOPROXY https://proxy.golang.org
+
+RUN mkdir -p /{{.opts.App.PackagePkg}}
+WORKDIR /{{.opts.App.PackagePkg}}
 
 {{if .opts.App.AsWeb -}}
 {{if .opts.App.WithWebpack -}}
@@ -17,7 +20,6 @@ RUN npm install --no-progress
 {{end -}}
 
 ADD . .
-RUN go get $(go list ./... | grep -v /vendor/)
 RUN buffalo build --static -o /bin/app
 
 # Uncomment to run the binary in "production" mode:


### PR DESCRIPTION
As we've fixed the issue about the extra S in `GO111MODULE` env variable, this PR aims to remove the rest of the `GOPATH` mode elements from our Dockerfile.

cc @markbates 