### PR TITLE
cache deps before building and copying source

### DIFF
--- a/genny/docker/templates/multi/Dockerfile.tmpl
+++ b/genny/docker/templates/multi/Dockerfile.tmpl
@@ -19,6 +19,13 @@ RUN npm install --no-progress
 {{end -}}
 {{end -}}
 
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
 ADD . .
 RUN buffalo build --static -o /bin/app
 

--- a/genny/docker/templates/standard/Dockerfile.tmpl
+++ b/genny/docker/templates/standard/Dockerfile.tmpl
@@ -19,6 +19,13 @@ RUN npm install --no-progress
 {{end -}}
 {{end -}}
 
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
 ADD . .
 RUN buffalo build --static -o /bin/app
 


### PR DESCRIPTION
cache deps before building and copying source so that we don't need to re-download as much
and so that source changes don't invalidate our downloaded layer

```
Step 8/22 : COPY go.mod go.mod
 ---> Using cache
 ---> cac8b7f69c8c
Step 9/22 : COPY go.sum go.sum
 ---> Using cache
 ---> b3c1bba1a11c
Step 10/22 : RUN go mod download
 ---> Using cache
 ---> 5ad7eef17090
```
ooh yeah