### PR TITLE
Fixes installing buffalo-auth plugin

### DIFF
--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	ht "github.com/gobuffalo/helpers/tags"
-	"github.com/gobuffalo/tags"
+	"github.com/gobuffalo/tags/v3"
 )
 
 type helperTag struct {


### PR DESCRIPTION
The plugin installation fails due to incorrect import path of tags package