### PR TITLE
Enable CI tests for PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push]
+on: [push, pull_request]
 jobs:
 
 


### PR DESCRIPTION
With the current configuration, tests were running only for internal contributions (the ones with branches pushed to gobuffalo/buffalo).

This enables CI tests for PRs from forks.