### PR TITLE
changing the packages to be replaced

### DIFF
--- a/buffalo/cmd/fix/fix.go
+++ b/buffalo/cmd/fix/fix.go
@@ -18,16 +18,16 @@ var replace = map[string]string{
 	"github.com/gobuffalo/genny":                   "github.com/gobuffalo/genny/v2",
 	"github.com/gobuffalo/pop":                     "github.com/gobuffalo/pop/v5",
 	"github.com/gobuffalo/pop/nulls":               "github.com/gobuffalo/nulls",
-	"github.com/gobuffalo/uuid":                    "github.com/gofrs/uuid/v3",
 	"github.com/markbates/pop":                     "github.com/gobuffalo/pop/v5",
 	"github.com/markbates/validate":                "github.com/gobuffalo/validate/v3",
 	"github.com/markbates/willie":                  "github.com/gobuffalo/httptest",
 	"github.com/satori/go.uuid":                    "github.com/gofrs/uuid",
 	"github.com/shurcooL/github_flavored_markdown": "github.com/gobuffalo/github_flavored_markdown",
-	"github.com/gofrs/uuid":                        "github.com/gofrs/uuid/v3",
 	"github.com/gobuffalo/validate":                "github.com/gobuffalo/validate/v3",
+	"github.com/gobuffalo/validate/validators":     "github.com/gobuffalo/validate/v3/validators",
 	"github.com/gobuffalo/suite":                   "github.com/gobuffalo/suite/v3",
 	"github.com/gobuffalo/buffalo-pop/":            "github.com/gobuffalo/buffalo-pop/v2",
+	"github.com/gobuffalo/buffalo-pop/pop/popmw":   "github.com/gobuffalo/buffalo-pop/v2/pop/popmw",
 }
 
 var ic = ImportConverter{

--- a/buffalo/cmd/fix/fix.go
+++ b/buffalo/cmd/fix/fix.go
@@ -18,6 +18,7 @@ var replace = map[string]string{
 	"github.com/gobuffalo/genny":                   "github.com/gobuffalo/genny/v2",
 	"github.com/gobuffalo/pop":                     "github.com/gobuffalo/pop/v5",
 	"github.com/gobuffalo/pop/nulls":               "github.com/gobuffalo/nulls",
+	"github.com/gobuffalo/uuid":                    "github.com/gofrs/uuid",
 	"github.com/markbates/pop":                     "github.com/gobuffalo/pop/v5",
 	"github.com/markbates/validate":                "github.com/gobuffalo/validate/v3",
 	"github.com/markbates/willie":                  "github.com/gobuffalo/httptest",


### PR DESCRIPTION
After trying to move one of my apps noticed a few issues we can cover with this PR.
  - `uuid` cannot be changed to be `uuid/v3`
  -  `validate/validators` needs to change to be `validate/v3/validators`
  -  `buffalo-pop/pop/popmw` needs to be changed to `buffalo-pop/v2/pop/popmw`