### PR TITLE
Add stack trace to ErrPanic event for easier debugging and monitoring

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -81,11 +82,12 @@ func (a *App) PanicHandler(next Handler) Handler {
 				default:
 					err = fmt.Errorf(fmt.Sprint(t))
 				}
-				err = err
 				events.EmitError(events.ErrPanic, err,
 					map[string]interface{}{
-						"context": c,
-						"app":     a,
+						"context":    c,
+						"app":        a,
+						"stacktrace": string(debug.Stack()),
+						"error":      err,
 					},
 				)
 				eh := a.ErrorHandlers.Get(http.StatusInternalServerError)


### PR DESCRIPTION
This PR adds more information to ErrPanic event for easier debugging and monitoring. Current ErrPanic event only has context and application information, doesn't have information about the panic itself. Event listeners to this event don't has enough information to handle the event.

This PR add:
- "error" field, contains the error object.
- "stacktrace" field, contains stack trace of the panic.