### PR TITLE
Update js template to support font awesome

### DIFF
--- a/buffalo/cmd/fix/fix.go
+++ b/buffalo/cmd/fix/fix.go
@@ -18,16 +18,17 @@ var replace = map[string]string{
 	"github.com/gobuffalo/genny":                   "github.com/gobuffalo/genny/v2",
 	"github.com/gobuffalo/pop":                     "github.com/gobuffalo/pop/v5",
 	"github.com/gobuffalo/pop/nulls":               "github.com/gobuffalo/nulls",
-	"github.com/gobuffalo/uuid":                    "github.com/gofrs/uuid/v3",
+	"github.com/gobuffalo/uuid":                    "github.com/gofrs/uuid",
 	"github.com/markbates/pop":                     "github.com/gobuffalo/pop/v5",
 	"github.com/markbates/validate":                "github.com/gobuffalo/validate/v3",
 	"github.com/markbates/willie":                  "github.com/gobuffalo/httptest",
 	"github.com/satori/go.uuid":                    "github.com/gofrs/uuid",
 	"github.com/shurcooL/github_flavored_markdown": "github.com/gobuffalo/github_flavored_markdown",
-	"github.com/gofrs/uuid":                        "github.com/gofrs/uuid/v3",
 	"github.com/gobuffalo/validate":                "github.com/gobuffalo/validate/v3",
+	"github.com/gobuffalo/validate/validators":     "github.com/gobuffalo/validate/v3/validators",
 	"github.com/gobuffalo/suite":                   "github.com/gobuffalo/suite/v3",
 	"github.com/gobuffalo/buffalo-pop/":            "github.com/gobuffalo/buffalo-pop/v2",
+	"github.com/gobuffalo/buffalo-pop/pop/popmw":   "github.com/gobuffalo/buffalo-pop/v2/pop/popmw",
 }
 
 var ic = ImportConverter{

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -81,11 +82,12 @@ func (a *App) PanicHandler(next Handler) Handler {
 				default:
 					err = fmt.Errorf(fmt.Sprint(t))
 				}
-				err = err
 				events.EmitError(events.ErrPanic, err,
 					map[string]interface{}{
-						"context": c,
-						"app":     a,
+						"context":    c,
+						"app":        a,
+						"stacktrace": string(debug.Stack()),
+						"error":      err,
 					},
 				)
 				eh := a.ErrorHandlers.Get(http.StatusInternalServerError)

--- a/genny/assets/webpack/templates/assets/js/application.js.tmpl
+++ b/genny/assets/webpack/templates/assets/js/application.js.tmpl
@@ -1,5 +1,6 @@
 require("expose-loader?$!expose-loader?jQuery!jquery");
 require("bootstrap/dist/js/bootstrap.bundle.js");
+require("@fortawesome/fontawesome-free/js/all.js");
 
 $(() => {
 


### PR DESCRIPTION
The latest version of font-awesome requires the js file to also be present for a glyph to work.  To see this work, add this code to any page template:

```html
<h3>
<a href=#" target="_blank"><i class="fab fa-twitter-square share" aria-hidden="true"></i></a>
</h3>
```

Without this JS file, the glyph will not render.