### PR TITLE
Pulls `latest` buffalo artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       - 7
 archives:
   -
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     replacements:
       '386': i386
       darwin: Darwin

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -33,8 +33,8 @@ RUN npm install -g --no-progress yarn \
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
 # Pulling docker binary from releases
-RUN wget https://github.com/gobuffalo/buffalo/releases/download/v0.16.1/buffalo_0.16.1_Linux_x86_64.tar.gz \
-    && tar -xzf buffalo_0.16.1_Linux_x86_64.tar.gz \
+RUN wget https://github.com/gobuffalo/buffalo/releases/latest/download/buffalo_Linux_x86_64.tar.gz \
+    && tar -xzf buffalo_Linux_x86_64.tar.gz \
     && mv buffalo $(go env GOPATH)/bin/buffalo
 
 RUN buffalo version

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -20,8 +20,8 @@ RUN npm i -g --no-progress yarn \
     && yarn config set yarn-offline-mirror-pruning true
 
 # Pulling docker binary from releases
-RUN wget https://github.com/gobuffalo/buffalo/releases/download/v0.16.1/buffalo_0.16.1_Linux_x86_64.tar.gz \
-    && tar -xzf buffalo_0.16.1_Linux_x86_64.tar.gz \
+RUN wget https://github.com/gobuffalo/buffalo/releases/latest/download/buffalo_Linux_x86_64.tar.gz \
+    && tar -xzf buffalo_Linux_x86_64.tar.gz \
     && mv buffalo $(go env GOPATH)/bin/buffalo
 
 RUN buffalo version


### PR DESCRIPTION
This PR changes the names of the artifact to avoid having to specify the artifact version in the Dockerfile. It will pull `latest` release from GitHub when building the image.