### PR TITLE
Extra release file for docker

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,8 @@ builds:
     goarm:
       - 6
       - 7
+    hooks:
+      post: tar -czvf dist/buffalo_Linux_x86_64.tar.gz dist/buffalo_linux_amd64
 archives:
   -
     replacements:
@@ -35,6 +37,9 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+release:
+  extra_files:
+    - glob: ./dist/buffalo_Linux_x86_64.tar.gz
 brews:
   -
     name: 'buffalo'

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -33,8 +33,8 @@ RUN npm install -g --no-progress yarn \
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
 # Pulling docker binary from releases
-RUN wget https://github.com/gobuffalo/buffalo/releases/download/v0.16.3/buffalo_0.16.3_Linux_x86_64.tar.gz \
-    && tar -xzf buffalo_0.16.3_Linux_x86_64.tar.gz \
+RUN wget https://github.com/gobuffalo/buffalo/releases/latest/download/buffalo_Linux_x86_64.tar.gz \
+    && tar -xzf buffalo_Linux_x86_64.tar.gz \
     && mv buffalo $(go env GOPATH)/bin/buffalo
 
 RUN buffalo version

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -20,8 +20,8 @@ RUN npm i -g --no-progress yarn \
     && yarn config set yarn-offline-mirror-pruning true
 
 # Pulling docker binary from releases
-RUN wget https://github.com/gobuffalo/buffalo/releases/download/v0.16.3/buffalo_0.16.3_Linux_x86_64.tar.gz \
-    && tar -xzf buffalo_0.16.3_Linux_x86_64.tar.gz \
+RUN wget https://github.com/gobuffalo/buffalo/releases/latest/download/buffalo_Linux_x86_64.tar.gz \
+    && tar -xzf buffalo_Linux_x86_64.tar.gz \
     && mv buffalo $(go env GOPATH)/bin/buffalo
 
 RUN buffalo version


### PR DESCRIPTION
**Context**
By moving to use released binaries in GitHub we simplified the build process of our Docker images and also used the same single binary produced by the release.

However this brought the inconvenience of having to include the version number in each of the releases causing that in some cases we end up with mismatching buffalo versions in last 3 or 4 buffalo docker images.

**Proposed solution**

As the docker build is the last one to build (by far), we could add another binary with a different naming that could be pulled by the docker build by using the `latest` reference for releases in GitHub.

```
https://github.com/gobuffalo/buffalo/releases/latest/download/buffalo_Linux_x86_64.tar.gz
```

But we need to ensure that each release going forward contains that file. 
This PR does that by changing our `.goreleaser.yml` to include that new binary for linux.
