### PR TITLE
Add in GZIP compression to file serving

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gobuffalo/pop/v5 v5.0.11
 	github.com/gobuffalo/tags/v3 v3.1.0
 	github.com/google/go-cmp v0.4.0
-	github.com/gorilla/handlers v1.4.2 // indirect
+	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/sessions v1.2.0
 	github.com/karrick/godirwalk v1.15.5

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gobuffalo/pop/v5 v5.0.11
 	github.com/gobuffalo/tags/v3 v3.1.0
 	github.com/google/go-cmp v0.4.0
+	github.com/gorilla/handlers v1.4.2 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/sessions v1.2.0
 	github.com/karrick/godirwalk v1.15.5

--- a/go.sum
+++ b/go.sum
@@ -609,6 +609,8 @@ github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE0
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
+github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/options.go
+++ b/options.go
@@ -62,6 +62,11 @@ type Options struct {
 	// a Buffalo application.
 	PreWares []PreWare `json:"-"`
 
+	// CompressFiles enables gzip compression of static files served by ServeFiles using
+	// gorilla's CompressHandler (https://godoc.org/github.com/gorilla/handlers#CompressHandler).
+	// Default is "false".
+	CompressFiles bool `json:"compress_files"`
+
 	Prefix  string          `json:"prefix"`
 	Context context.Context `json:"-"`
 

--- a/route_mappings.go
+++ b/route_mappings.go
@@ -115,7 +115,11 @@ func (a *App) fileServer(fs http.FileSystem) http.Handler {
 		fsh.ServeHTTP(w, r)
 	})
 
-	return handlers.CompressHandler(baseHandler)
+	if a.CompressFiles {
+		return handlers.CompressHandler(baseHandler)
+	}
+
+	return baseHandler
 }
 
 type newable interface {

--- a/route_mappings.go
+++ b/route_mappings.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/flect"
 	"github.com/gobuffalo/flect/name"
+	"github.com/gorilla/handlers"
 )
 
 const (
@@ -99,7 +100,7 @@ func (a *App) ServeFiles(p string, root http.FileSystem) {
 
 func (a *App) fileServer(fs http.FileSystem) http.Handler {
 	fsh := http.FileServer(fs)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f, err := fs.Open(path.Clean(r.URL.Path))
 		if os.IsNotExist(err) {
 			eh := a.ErrorHandlers.Get(http.StatusNotFound)
@@ -113,6 +114,8 @@ func (a *App) fileServer(fs http.FileSystem) http.Handler {
 		w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%s", maxAge))
 		fsh.ServeHTTP(w, r)
 	})
+
+	return handlers.CompressHandler(baseHandler)
 }
 
 type newable interface {


### PR DESCRIPTION
Compressing static assets like CSS/JS files can lead to big performance improvements. While this is typically done by a frontend proxy like Apache or Nginx, some providers like Heroku do not offer this and instead rely on the server to implement content compression.

The existing middleware API allows a developer to add compression *except* for files served via `ServeFiles` (static assets) where compression would be most useful. In this case, `ServeFiles` creates a separate `http.Handler` that is outside of the middleware stack.

To solve this problem for statically-served sites, wrap the file server's `http.Handler` with Gorilla's `CompressionHandler`. This handler just checks the request's `Accept-Encoding` header to enable or disable compression. See: https://godoc.org/github.com/gorilla/handlers#CompressHandler

This change should be invisible to users with the only difference being the return of gzipped responses if the appropriate `Accept-Header` is sent. In my production environment this led to ~2/3rds reduction in bundle sizes. 

/cc @paganotoni 

Fixes #1968 