### PR TITLE
Fix GO111MODULE value in build Docker images

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@ FROM golang:latest
 EXPOSE 3000
 
 ENV GOPROXY=https://proxy.golang.org
-ENV GO111MODULE=ON
+ENV GO111MODULE=on
 
 RUN go version
 

--- a/Dockerfile.slim.build
+++ b/Dockerfile.slim.build
@@ -2,7 +2,7 @@ FROM golang:alpine
 EXPOSE 3000
 
 ENV GOPROXY=https://proxy.golang.org
-ENV GO111MODULE=ON
+ENV GO111MODULE=on
 
 ENV GOPROXY=https://proxy.golang.org 
 


### PR DESCRIPTION
`ON` is an invalid value for GO111MODULE which prevents Go binaries from executing in the container with error:

```
go: unknown environment setting GO111MODULE=ON
```

This PR fixes the parameter.