### PR TITLE
Fix npm's package.json permissions

### DIFF
--- a/buffalo/cmd/fix/npm.go
+++ b/buffalo/cmd/fix/npm.go
@@ -62,7 +62,7 @@ func AddPackageJSONScripts(r *Runner) error {
 			return fmt.Errorf("could not rewrite package.json: %s", err.Error())
 		}
 
-		ioutil.WriteFile("package.json", b, 644)
+		ioutil.WriteFile("package.json", b, 0644)
 	} else {
 		fmt.Println("~~~ package.json doesn't need to be patched, skipping. ~~~")
 	}


### PR DESCRIPTION
Changed created file permissions from 644 (`-w----r--`) to 0644 (`rw-r--r--`) when calling `WriteFile(...)`.

PoC:
```
dc@jhtc:~/gogo$ cat main.go
package main

import "io/ioutil"

func main() {
    ioutil.WriteFile("644", []byte("content"), 644)
    ioutil.WriteFile("0644", []byte("content"), 0644)
}
dc@jhtc:~/gogo$ go run main.go
dc@jhtc:~/gogo$ ls -la
total 28
drwxrwxr-x   2 dc dc  4096 Jun  9 16:42 .
drwxr-xr-x 124 dc dc 12288 Jun  9 16:42 ..
-rw-r--r--   1 dc dc     7 Jun  9 16:42 0644
--w----r--   1 dc dc     7 Jun  9 16:42 644
-rw-rw-r--   1 dc dc   156 Jun  9 16:42 main.go
```