### PR TITLE
Task binding cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
     env:
       GO111MODULE: on

--- a/binding/binding.go
+++ b/binding/binding.go
@@ -2,8 +2,10 @@ package binding
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gobuffalo/buffalo/binding/decoders"
+	"github.com/gobuffalo/nulls"
 	"github.com/monoculum/formam"
 )
 
@@ -14,16 +16,16 @@ var (
 	// information on how this impacts file uploads.
 	MaxFileMemory int64 = 5 * 1024 * 1024
 
-	formDecoder = formam.NewDecoder(&formam.DecoderOptions{
-		TagName:           "form",
-		IgnoreUnknownKeys: true,
-	})
+	// formDecoder (formam) that will be used across ContentTypeBinders
+	formDecoder = buildFormDecoder()
 
 	// BaseRequestBinder is an instance of the requestBinder, it comes with preconfigured
 	// content type binders for HTML, JSON, XML and Files, as well as custom types decoders
 	// for time.Time and nulls.Time
 	BaseRequestBinder = NewRequestBinder(
-		NewHTMLContentTypeBinder(formDecoder),
+		HTMLContentTypeBinder{
+			decoder: formDecoder,
+		},
 		JSONContentTypeBinder{},
 		XMLRequestTypeBinder{},
 		FileRequestTypeBinder{
@@ -31,6 +33,19 @@ var (
 		},
 	)
 )
+
+// buildFormDecoder that will be used in the package. This method adds some custom decoders for time.Time and nulls.Time.
+func buildFormDecoder() *formam.Decoder {
+	decoder := formam.NewDecoder(&formam.DecoderOptions{
+		TagName:           "form",
+		IgnoreUnknownKeys: true,
+	})
+
+	decoder.RegisterCustomType(decoders.TimeDecoderFn(), []interface{}{time.Time{}}, nil)
+	decoder.RegisterCustomType(decoders.NullTimeDecoderFn(), []interface{}{nulls.Time{}}, nil)
+
+	return decoder
+}
 
 // RegisterTimeFormats allows to add custom time layouts that
 // the binder will be able to use for decoding.

--- a/binding/html_content_type_binder.go
+++ b/binding/html_content_type_binder.go
@@ -2,27 +2,13 @@ package binding
 
 import (
 	"net/http"
-	"time"
 
-	"github.com/gobuffalo/buffalo/binding/decoders"
-	"github.com/gobuffalo/nulls"
 	"github.com/monoculum/formam"
 )
 
 // HTMLContentTypeBinder is in charge of binding HTML request types.
 type HTMLContentTypeBinder struct {
 	decoder *formam.Decoder
-}
-
-// NewHTMLContentTypeBinder returns an instance of HTMLContentTypeBinder with
-// custom type decoders registered for Time and nulls.Time
-func NewHTMLContentTypeBinder(decoder *formam.Decoder) HTMLContentTypeBinder {
-	decoder.RegisterCustomType(decoders.TimeDecoderFn(), []interface{}{time.Time{}}, nil)
-	decoder.RegisterCustomType(decoders.NullTimeDecoderFn(), []interface{}{nulls.Time{}}, nil)
-
-	return HTMLContentTypeBinder{
-		decoder: decoder,
-	}
 }
 
 // ContentTypes that will be used to identify HTML requests

--- a/render/js_test.go
+++ b/render/js_test.go
@@ -124,6 +124,9 @@ func Test_JavaScript_HTML_Partial(t *testing.T) {
 	bb := &bytes.Buffer{}
 
 	r.NoError(h.Render(bb, Data{}))
-	pre := `let a = "\x3Cdiv`
-	r.True(strings.HasPrefix(bb.String(), pre))
+	r.Contains(bb.String(), `id`)
+	r.Contains(bb.String(), `foo`)
+
+	// To check it has escaped the partial
+	r.NotContains(bb.String(), `<div id="foo">`)
 }


### PR DESCRIPTION
This makes the file binding used the same decoder configuration as the form decoder.