### PR TITLE
Fix 'got a git repository' error when building Docker container

### DIFF
--- a/genny/docker/templates/multi/Dockerfile.tmpl
+++ b/genny/docker/templates/multi/Dockerfile.tmpl
@@ -25,6 +25,8 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
+# Buffalo complains if it is not run inside a git repo
+RUN git init
 
 ADD . .
 RUN buffalo build --static -o /bin/app

--- a/genny/docker/templates/standard/Dockerfile.tmpl
+++ b/genny/docker/templates/standard/Dockerfile.tmpl
@@ -25,6 +25,8 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
+# Buffalo complains if it is not run inside a git repo
+RUN git init
 
 ADD . .
 RUN buffalo build --static -o /bin/app


### PR DESCRIPTION
## Problem

When building a Buffalo app in a docker container a strange error was thrown but the build would complete successfully:

```
remote: Digest: sha256:92867f528f630f5bf005d689d0b4ba2f2b836311a4780b55b2939e2f52a9d665
remote: Status: Downloaded newer image for gobuffalo/buffalo:v0.16.14
remote:  ---> a1dd7fd2e2df
remote: Step 2/26 : ENV GO111MODULE on
remote:  ---> Running in 89295b6ec0f4
remote: Removing intermediate container 89295b6ec0f4
remote:  ---> 4cd418d36fc1
remote: Step 3/26 : ENV GOPROXY http://proxy.golang.org
remote:  ---> Running in c69be3eff0ff
remote: Removing intermediate container c69be3eff0ff
remote:  ---> f4be33df0b5c
remote: Step 4/26 : RUN mkdir -p /src/github.com/REDACTED
remote:  ---> Running in b82307115821
remote: Removing intermediate container b82307115821
remote:  ---> cba902efa2c6
remote: Step 5/26 : WORKDIR /src/github.com/REDACTED
remote:  ---> Running in 83b58a59e29c
remote: Removing intermediate container 83b58a59e29c
remote:  ---> da642a1e3b65
remote: Step 6/26 : ADD package.json .
remote:  ---> 459d6c56c425
remote: Step 7/26 : ADD yarn.lock .
remote:  ---> fd73d444bca7
remote: Step 8/26 : RUN yarn install --no-progress
remote:  ---> Running in 05c78a296961
remote: yarn install v1.22.4
remote: [1/4] Resolving packages...
remote: [2/4] Fetching packages...
remote: info fsevents@1.2.13: The platform "linux" is incompatible with this module.
remote: info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
remote: info fsevents@2.1.3: The platform "linux" is incompatible with this module.
remote: info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
remote: [3/4] Linking dependencies...
remote: [4/4] Building fresh packages...
remote: Done in 19.67s.
remote: Removing intermediate container 05c78a296961
remote:  ---> 490da65f0ba6
remote: Step 9/26 : COPY go.mod go.mod
remote:  ---> 7df2a3a12e34
remote: Step 10/26 : COPY go.sum go.sum
remote:  ---> 30b716e2cedd
remote: Step 11/26 : RUN go mod download
remote:  ---> Running in 327d972716fd
remote: Removing intermediate container 327d972716fd
remote:  ---> 0c97e39c81ab
remote: Step 12/26 : ADD . .
remote:  ---> 6b78a534067d
remote: Step 13/26 : RUN cd /src/github.com/REDACTED
remote:  ---> Running in 5dd9ec5332de
remote: Removing intermediate container 5dd9ec5332de
remote:  ---> 6f7663dfbe4c
remote: Step 14/26 : RUN buffalo build --static -o /bin/app
remote:  ---> Running in 8ed99d5fced6
remote: fatal: not a git repository (or any of the parent directories): .git
remote: ERRO[2020-09-14T04:39:38Z] exit status 128
remote: Verifying deploy... done.
remote: Running release command...
remote:
remote: [POP] 2020/09/14 04:41:35 warn - ignoring file .git-keep because it does not match the migration file pattern
remote: [POP] 2020/09/14 04:41:35 warn - ignoring file .pop-tmp.md because it does not match the migration file pattern
remote: [POP] 2020/09/14 04:41:35 info - Migrations already up to date, nothing to apply
remote: [POP] 2020/09/14 04:41:35 info - 0.0431 seconds
remote: Waiting for release.... done.
```

I learned from (https://github.com/gobuffalo/buffalo/issues/2028) that `buffalo` creates a git repository if it is run in a directory without. That is the source of the `ERRO` message above (which might be more appropriate to title a warning).

I'm not attempting to modify that behavior, as the commentor in (https://github.com/gobuffalo/buffalo/issues/2028) asked.

## Changes

I am avoiding Buffalo needing to complain about not being in a git repository and attempting to create one itself by running `git init` in the copied source directory. This is a light-weight operation and the directory itself is temporary - just being needed momentarily to build the binary.

The alternative approach would be to copy the user's `.git` directory into the Docker container. This is not idea because it could be a very large directory, thereby increasing the container. It is also unnecessary for the purposes of building a Buffalo binary.

## Testing

Testing on a local application with the changes - it did not display the error message:

```
Done in 27.56s.
Removing intermediate container 34af82e82fa6
 ---> 2d2079091a84
Step 9/26 : COPY go.mod go.mod
 ---> ed7a79eba6a3
Step 10/26 : COPY go.sum go.sum
 ---> ef87dca08ff2
Step 11/26 : RUN go mod download
 ---> Running in 935d0504d598
Removing intermediate container 935d0504d598
 ---> b154340008b3
Step 12/26 : RUN git init
 ---> Running in 9c82f38cfa77
Initialized empty Git repository in /src/github.com/leoromanovsky/REDACTED/.git/
Removing intermediate container 9c82f38cfa77
 ---> 40f6576f4951
Step 13/26 : ADD . .
 ---> 3909c4509bbd
Step 14/26 : RUN buffalo build --static -o /bin/app
 ---> Running in 9c33b6d6f473
# github.com/leoromanovsky/REDACTED
/usr/bin/ld: /tmp/go-link-061009694/000007.o: in function `mygetgrouplist':
/workdir/go/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-061009694/000006.o: in function `mygetgrgid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-061009694/000006.o: in function `mygetgrnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-061009694/000006.o: in function `mygetpwnam_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-061009694/000006.o: in function `mygetpwuid_r':
/workdir/go/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-061009694/000004.o: in function `_cgo_26061493d47f_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
Removing intermediate container 9c33b6d6f473
 ---> c355980c1f66
Step 15/26 : FROM alpine
latest: Pulling from library/alpine
df20fa9351a1: Pull complete
Digest: sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
Status: Downloaded newer image for alpine:latest
 ---> a24bb4013296
Step 16/26 : RUN apk add --no-cache curl
 ---> Running in 9c79b62dbd7e
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/4) Installing ca-certificates (20191127-r4)
(2/4) Installing nghttp2-libs (1.41.0-r0)
(3/4) Installing libcurl (7.69.1-r0)
(4/4) Installing curl (7.69.1-r0)
Executing busybox-1.31.1-r16.trigger
Executing ca-certificates-20191127-r4.trigger
OK: 7 MiB in 18 packages
Removing intermediate container 9c79b62dbd7e
 ---> d7875879240a
Step 17/26 : RUN apk add --no-cache bash
 ---> Running in 566974a6cc54
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/4) Installing ncurses-terminfo-base (6.2_p20200523-r0)
(2/4) Installing ncurses-libs (6.2_p20200523-r0)
(3/4) Installing readline (8.0.4-r0)
(4/4) Installing bash (5.0.17-r0)
Executing bash-5.0.17-r0.post-install
Executing busybox-1.31.1-r16.trigger
OK: 9 MiB in 22 packages
Removing intermediate container 566974a6cc54
 ---> 1887f52a3fa9
Step 18/26 : RUN apk add --no-cache ca-certificates
 ---> Running in 46d4b59df3af
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
OK: 9 MiB in 22 packages
Removing intermediate container 46d4b59df3af
 ---> 705a3a215739
Step 19/26 : RUN cd /
 ---> Running in 6fe2ae53fca8
Removing intermediate container 6fe2ae53fca8
 ---> 5328e7e5579b
...REDACTED...
Removing intermediate container 1a05dd626c9c
 ---> 5fc6d4fd9fe2
Step 22/26 : WORKDIR /bin/
 ---> Running in 69761bc4832f
Removing intermediate container 69761bc4832f
 ---> 68b10035914d
Step 23/26 : COPY --from=builder /bin/app .
 ---> c95aca90d553
Step 24/26 : ENV ADDR=0.0.0.0
 ---> Running in 0c7e6c5d917b
Removing intermediate container 0c7e6c5d917b
 ---> 4b892d73f384
Step 25/26 : EXPOSE 3000
 ---> Running in 2bf30298fa21
Removing intermediate container 2bf30298fa21
 ---> a051440b2393
Step 26/26 : CMD exec /bin/app
 ---> Running in 0b425b8bd4d5
Removing intermediate container 0b425b8bd4d5
 ---> 96144062a260
Successfully built 96144062a260
Successfully tagged REDACTED:latest
111

Fixes: 
* https://github.com/gobuffalo/buffalo/issues/2048
* https://github.com/gobuffalo/buffalo/issues/2033