### PR TITLE
Update 'goreleaser' config to use new brew syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ changelog:
 brews:
   -
     name: 'buffalo'
-    github:
+    tap:
       owner: 'gobuffalo'
       name: 'homebrew-tap'
     install: |


### PR DESCRIPTION
Previous config used `brews`, which has been deprecated and superseded
by `tap`:
https://goreleaser.com/deprecations/#brewsgithub