### PR TITLE
Run go mod tidy when initializing a new project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Set up Go 1.14
+        name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
       -
         name: Checkout Code

--- a/buffalo/cmd/new.go
+++ b/buffalo/cmd/new.go
@@ -201,6 +201,12 @@ var newCmd = &cobra.Command{
 		}
 		run.WithGroup(gg)
 
+		g := genny.New()
+		g.Command(exec.Command("go", "mod", "tidy"))
+		if err := run.With(g); err != nil {
+			return nil
+		}
+
 		if err := run.WithNew(gogen.Fmt(app.Root)); err != nil {
 			return err
 		}


### PR DESCRIPTION
This addresses https://github.com/gobuffalo/buffalo/issues/2117

With this change calling `buffalo dev` immediately after `buffalo new` should pass without errors. No need to manually call `go mod tidy`.