### PR TITLE
hotfix: allowing leading slash when call r.HTML(template_name)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/render/html.go
+++ b/render/html.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"html"
+	"strings"
 
 	"github.com/gobuffalo/github_flavored_markdown"
 	"github.com/gobuffalo/plush/v4"
@@ -28,6 +29,14 @@ func HTML(names ...string) Renderer {
 // in the options, then that layout file will be used
 // automatically.
 func (e *Engine) HTML(names ...string) Renderer {
+	// just allow leading slash and remove them here.
+	// generated actions were various by buffalo versions.
+	tmp := []string{}
+	for _, name := range names {
+		tmp = append(tmp, strings.TrimPrefix(name, "/"))
+	}
+	names = tmp
+
 	if e.HTMLLayout != "" && len(names) == 1 {
 		names = append(names, e.HTMLLayout)
 	}

--- a/render/html_test.go
+++ b/render/html_test.go
@@ -68,3 +68,22 @@ func Test_HTML_WithLayout_Override(t *testing.T) {
 	r.NoError(h.Render(bb, Data{"name": "Mark"}))
 	r.Equal("<html>Mark</html>", strings.TrimSpace(bb.String()))
 }
+
+func Test_HTML_LeadingSlash(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile(htmlTemplate, []byte("<%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile(htmlLayout, []byte("<body><%= yield %></body>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+	e.HTMLLayout = htmlLayout
+
+	h := e.HTML("/my-template.html") // instead of "my-template.html"
+	r.Equal("text/html; charset=utf-8", h.ContentType())
+	bb := &bytes.Buffer{}
+
+	r.NoError(h.Render(bb, Data{"name": "Mark"}))
+	r.Equal("<body>Mark</body>", strings.TrimSpace(bb.String()))
+}

--- a/runtime/version.go
+++ b/runtime/version.go
@@ -1,4 +1,4 @@
 package runtime
 
 // Version is the current version of the buffalo binary
-var Version = "v0.18.0"
+var Version = "v0.18.1"


### PR DESCRIPTION
Previously, we allowed a leading slash in the template name when calling `r.HTML("resources/index.plush.html")` which is actually not required. (as I remember it was different by versions) Also, we generated actions with or without leading slashes before. (also different by `buffalo` versions.)

This hotfix makes buffalo keep the behavior so the user can migrate their existing code with a small modification as possible.

fixes gobuffalo/cli#55