### PR TITLE
Feature/Addition Host domain

### DIFF
--- a/route_info.go
+++ b/route_info.go
@@ -83,7 +83,7 @@ func (ri *RouteInfo) BuildPathHelper() RouteHelperFunc {
 			return "", fmt.Errorf("missing parameters for %v: %s", cRoute.Path, err)
 		}
 
-		result := url.Path
+		result := url.String()
 		result = addExtraParamsTo(result, opts)
 
 		return template.HTML(result), nil

--- a/route_mappings.go
+++ b/route_mappings.go
@@ -84,7 +84,7 @@ func (a *App) Mount(p string, h http.Handler) {
 	a.ANY(path, WrapHandler(http.StripPrefix(prefix, h)))
 }
 
-// Host creates a new "*App" that would only works if the domain matches.
+// Host creates a new "*App" group that matches the domain passed.
 // This is useful for creating groups of end-points for different domains.
 /*
 	a.Host("www.example.com")

--- a/route_mappings.go
+++ b/route_mappings.go
@@ -84,6 +84,29 @@ func (a *App) Mount(p string, h http.Handler) {
 	a.ANY(path, WrapHandler(http.StripPrefix(prefix, h)))
 }
 
+// Host creates a new "*App" that would only works if the domain matches.
+// This is useful for creating groups of end-points for different domains.
+/*
+	a.Host("www.example.com")
+	a.Host("{subdomain}.example.com")
+	a.Host("{subdomain:[a-z]+}.example.com")
+*/
+func (a *App) Host(h string) *App {
+	g := New(a.Options)
+
+	g.router = a.router.Host(h).Subrouter()
+	g.RouteNamer = a.RouteNamer
+	g.Middleware = a.Middleware.clone()
+	g.ErrorHandlers = a.ErrorHandlers
+	g.root = a
+
+	if a.root != nil {
+		g.root = a.root
+	}
+
+	return g
+}
+
 // ServeFiles maps an path to a directory on disk to serve static files.
 // Useful for JavaScript, images, CSS, etc...
 /*


### PR DESCRIPTION
This PR adds new functionality for Buffalo, by using the [Host](https://github.com/gorilla/mux#matching-routes) function from Gorilla/Mux, buffalo can now restrict the handlers and render those that only match the specified host. This is very useful if you have multiple portals in the same application and/or want to use the same path for different portals.

```
...

func HomeApp(c buffalo.Context) error {
	return c.Render(http.StatusOK, r.String("OK APP"))
}

func HomeLMS(c buffalo.Context) error {
	return c.Render(http.StatusOK, r.String("OK LMS"))
}

func New() *buffalo.App {
	bapp := buffalo.New(buffalo.Options{
		Env:         envy.Get("GO_ENV", "development"),
		SessionName: "_application_session",
	})

        app := bapp.Host("app.domain.com")
        app.GET("/dashboard", HomeApp) // This will render the dashboard for the Application

        lms := bapp.Host("lms.domain.com")
        lms.GET("/dashboard", HomeLMS) // This will render the dashboard for the LMS

	return bapp
}

...
```

When testing, you need to specify the exact path, including the host, otherwise it will return a 404:

```
func (as ActionSuite) Test_App_Dashboard() {
    // This one will not throw a 404
    res := as.HTML("http://app.domain.com/dashboard/").Get()
    as.Equal(http.StatusOK, res.Code)
    as.Contains(res.Body.String(), "OK APP")
}

func (as ActionSuite) Test_LMS_Dashboard() {
    // This one will throw a 404
    res := as.HTML("http://cms.domain.com/dashboard/").Get()
    as.Equal(http.StatusOK, res.Code)
    as.Contains(res.Body.String(), "OK LMS")
}
```