### PR TITLE
Buffalo should respect http status when returning error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -115,6 +115,7 @@ func (a *App) defaultErrorMiddleware(next Handler) Handler {
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			status = http.StatusNotFound
+			fallthrough
 		default:
 			var h HTTPError
 			if errors.As(err, &h) {

--- a/errors.go
+++ b/errors.go
@@ -112,15 +112,12 @@ func (a *App) defaultErrorMiddleware(next Handler) Handler {
 		}
 		status := http.StatusInternalServerError
 		// unpack root err and check for HTTPError
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		if errors.Is(err, sql.ErrNoRows) {
 			status = http.StatusNotFound
-			fallthrough
-		default:
-			var h HTTPError
-			if errors.As(err, &h) {
-				status = h.Status
-			}
+		}
+		var h HTTPError
+		if errors.As(err, &h) {
+			status = h.Status
 		}
 		payload := events.Payload{
 			"context": c,

--- a/route_info_test.go
+++ b/route_info_test.go
@@ -2,12 +2,12 @@ package buffalo
 
 import (
 	"database/sql"
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/httptest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,12 +23,16 @@ func Test_RouteInfo_ServeHTTP_SQL_Error(t *testing.T) {
 		return sql.ErrNoRows
 	})
 
+	app.GET("/bad-2", func(c Context) error {
+		return sql.ErrTxDone
+	})
+
 	app.GET("/gone-unwrap", func(c Context) error {
-		return c.Error(http.StatusGone, sql.ErrNoRows)
+		return c.Error(http.StatusGone, sql.ErrTxDone)
 	})
 
 	app.GET("/gone-wrap", func(c Context) error {
-		return c.Error(http.StatusGone, errors.Wrap(sql.ErrNoRows, "some error wrapping here"))
+		return c.Error(http.StatusGone, fmt.Errorf("some error wrapping here: %w", sql.ErrNoRows))
 	})
 
 	w := httptest.New(app)

--- a/route_info_test.go
+++ b/route_info_test.go
@@ -23,7 +23,11 @@ func Test_RouteInfo_ServeHTTP_SQL_Error(t *testing.T) {
 		return sql.ErrNoRows
 	})
 
-	app.GET("/wrap", func(c Context) error {
+	app.GET("/gone-unwrap", func(c Context) error {
+		return c.Error(http.StatusGone, sql.ErrNoRows)
+	})
+
+	app.GET("/gone-wrap", func(c Context) error {
 		return c.Error(http.StatusGone, errors.Wrap(sql.ErrNoRows, "some error wrapping here"))
 	})
 
@@ -35,6 +39,9 @@ func Test_RouteInfo_ServeHTTP_SQL_Error(t *testing.T) {
 	res = w.HTML("/bad").Get()
 	r.Equal(http.StatusNotFound, res.Code)
 
-	res = w.HTML("/wrap").Get()
+	res = w.HTML("/gone-wrap").Get()
+	r.Equal(http.StatusGone, res.Code)
+
+	res = w.HTML("/gone-unwrap").Get()
 	r.Equal(http.StatusGone, res.Code)
 }

--- a/route_info_test.go
+++ b/route_info_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/httptest"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +23,10 @@ func Test_RouteInfo_ServeHTTP_SQL_Error(t *testing.T) {
 		return sql.ErrNoRows
 	})
 
+	app.GET("/wrap", func(c Context) error {
+		return c.Error(http.StatusGone, errors.Wrap(sql.ErrNoRows, "some error wrapping here"))
+	})
+
 	w := httptest.New(app)
 
 	res := w.HTML("/good").Get()
@@ -29,4 +34,7 @@ func Test_RouteInfo_ServeHTTP_SQL_Error(t *testing.T) {
 
 	res = w.HTML("/bad").Get()
 	r.Equal(http.StatusNotFound, res.Code)
+
+	res = w.HTML("/wrap").Get()
+	r.Equal(http.StatusGone, res.Code)
 }


### PR DESCRIPTION
When returning an HTTP Status different than 404 caused by an "sql.ErrNoRows" buffalo is automatically changing the error status to a 404 error. Buffalo should respect the error status passed on the return.