### PR TITLE
Fix #2211

### DIFF
--- a/default_context.go
+++ b/default_context.go
@@ -195,7 +195,6 @@ var mapType = reflect.ValueOf(map[string]interface{}{}).Type()
 // Redirect a request with the given status to the given URL.
 func (d *DefaultContext) Redirect(status int, url string, args ...interface{}) error {
 	if d.Session() != nil {
-		d.Flash().Clear()
 		d.Flash().persist(d.Session())
 		if err := d.Session().Save(); err != nil {
 			return HTTPError{Status: http.StatusInternalServerError, Cause: err}

--- a/error_templates.go
+++ b/error_templates.go
@@ -1,7 +1,7 @@
 package buffalo
 
 import (
-	_ "embed"
+	_ "embed" // needed to embed the templates.
 )
 
 var (


### PR DESCRIPTION
This PR fixes the outlined issue in #2211. Flash should not be cleared with redirects, only with renders. Thanks @dmuriel and @SenatorSpooky for reporting and researching it.