### PR TITLE
Fixed multi-homing feature and related bugs. (#2222)

### DIFF
--- a/app.go
+++ b/app.go
@@ -58,6 +58,8 @@ func New(opts Options) *App {
 
 		RouteNamer: baseRouteNamer{},
 	}
+	a.Home.app = a     // replace root.
+	a.Home.appSelf = a // temporary, reverse reference to the group app.
 
 	dem := a.defaultErrorMiddleware
 	a.Middleware = newMiddlewareStack(dem)

--- a/app.go
+++ b/app.go
@@ -14,15 +14,13 @@ import (
 // Without an App you can't do much!
 type App struct {
 	Options
-	// Middleware returns the current MiddlewareStack for the App/Group.
-	Middleware    *MiddlewareStack `json:"-"`
-	ErrorHandlers ErrorHandlers    `json:"-"`
-	router        *mux.Router
-	moot          *sync.RWMutex
-	routes        RouteList
-	root          *App
-	children      []*App
-	filepaths     []string
+	// Middleware, ErrorHandlers, router, and filepaths are moved to Home.
+	Home
+	moot   *sync.RWMutex
+	routes RouteList
+	// TODO: to be deprecated #road-to-v1
+	root     *App
+	children []*App
 
 	// Routenamer for the app. This field provides the ability to override the
 	// base route namer for something more specific to the app.
@@ -44,11 +42,16 @@ func New(opts Options) *App {
 
 	a := &App{
 		Options: opts,
-		ErrorHandlers: ErrorHandlers{
-			http.StatusNotFound:            defaultErrorHandler,
-			http.StatusInternalServerError: defaultErrorHandler,
+		Home: Home{
+			name:   opts.Name,
+			host:   opts.Host,
+			prefix: opts.Prefix,
+			ErrorHandlers: ErrorHandlers{
+				http.StatusNotFound:            defaultErrorHandler,
+				http.StatusInternalServerError: defaultErrorHandler,
+			},
+			router: mux.NewRouter(),
 		},
-		router:   mux.NewRouter(),
 		moot:     &sync.RWMutex{},
 		routes:   RouteList{},
 		children: []*App{},

--- a/home.go
+++ b/home.go
@@ -1,0 +1,39 @@
+package buffalo
+
+import (
+	"github.com/gorilla/mux"
+)
+
+/* TODO: consider to split out Home (or Router, whatever) from App #road-to-v1
+   Group and Domain based multi-homing are actually not an App if the concept
+   of the App represents the application. The App should be only one for whole
+   application.
+
+   For an extreme example, App.Group().Stop() or even App.Group().Serve() are
+   still valid function calls while they should not be allowed and the result
+   could be strage.
+*/
+
+// Home is a container for Domains and Groups that independantly serves a
+// group of pages with its own Middleware and ErrorHandlers. It is usually
+// a multi-homed server domain or group of paths under a certain prefix.
+//
+// While the App is for managing whole application life cycle along with its
+// default Home, including initializing and stopping its all components such
+// as listeners and long-running jobs, Home is only for a specific group of
+// services to serve its service logic efficiently.
+type Home struct {
+	app     *App // will replace App.root
+	appSelf *App // temporary while the App is in action.
+	// replace Options' Name, Host, and Prefix
+	name   string
+	host   string
+	prefix string
+
+	// moved from App
+	// Middleware returns the current MiddlewareStack for the App/Group.
+	Middleware    *MiddlewareStack `json:"-"`
+	ErrorHandlers ErrorHandlers    `json:"-"`
+	router        *mux.Router
+	filepaths     []string
+}

--- a/route.go
+++ b/route.go
@@ -65,11 +65,20 @@ type RouteHelperFunc func(opts map[string]interface{}) (template.HTML, error)
 // and the name of the Handler defined to process that route.
 type RouteList []*RouteInfo
 
+var methodOrder = map[string]string{
+	"GET":    "1",
+	"POST":   "2",
+	"PUT":    "3",
+	"DELETE": "4",
+}
+
 func (a RouteList) Len() int      { return len(a) }
 func (a RouteList) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a RouteList) Less(i, j int) bool {
-	x := a[i].Path // + a[i].Method
-	y := a[j].Path // + a[j].Method
+	// NOTE: it was used for sorting of app.routes but we don't sort the routes anymore.
+	// keep it for compatibility but could be deprecated.
+	x := a[i].App.host + a[i].Path + methodOrder[a[i].Method]
+	y := a[j].App.host + a[j].Path + methodOrder[a[j].Method]
 	return x < y
 }
 

--- a/route.go
+++ b/route.go
@@ -11,6 +11,7 @@ import (
 // Routes returns a list of all of the routes defined
 // in this application.
 func (a *App) Routes() RouteList {
+	// CHKME: why this function is exported? can we deprecate it?
 	if a.root != nil {
 		return a.root.routes
 	}

--- a/route_info.go
+++ b/route_info.go
@@ -49,7 +49,7 @@ func (ri *RouteInfo) Alias(aliases ...string) *RouteInfo {
 func (ri *RouteInfo) Name(name string) *RouteInfo {
 	routeIndex := -1
 	for index, route := range ri.App.Routes() {
-		if route.Path == ri.Path && route.Method == ri.Method {
+		if route.App.host == ri.App.host && route.Path == ri.Path && route.Method == ri.Method {
 			routeIndex = index
 			break
 		}

--- a/route_mappings_test.go
+++ b/route_mappings_test.go
@@ -155,13 +155,13 @@ func Test_App_Routes_Resource(t *testing.T) {
 	}
 }
 
-func Test_App_Host(t *testing.T) {
+func Test_App_VirtualHost(t *testing.T) {
 	r := require.New(t)
 
 	a1 := New(Options{})
 	r.Nil(a1.root)
 
-	h1 := a1.Host("www.example.com")
+	h1 := a1.VirtualHost("www.example.com")
 	h1.GET("/foo", voidHandler)
 
 	routes := h1.Routes()
@@ -177,7 +177,7 @@ func Test_App_Host(t *testing.T) {
 	a2 := New(Options{})
 	r.Nil(a1.root)
 
-	h2 := a2.Host("{subdomain}.example.com")
+	h2 := a2.VirtualHost("{subdomain}.example.com")
 	h2.GET("/foo", voidHandler)
 	h2.GET("/foo/{id}", voidHandler).Name("fooID")
 


### PR DESCRIPTION
This will fix #2222.

In brief,
- added structure `Home` as an interim solution (hope to be reshaped as `Group` structure in v1)
- adapted to the new structure
- fixed bugs related to this feature and pre-existing small ambiguous things (related to routes and middleware handling)
- renamed the function from `Host()` to `VirtualHost()` to make the name clear, and avoid conflicting with `App.Options.Host`.
- added clarified function descriptions for involved functions.

More details (including the details of fixed bugs or symptoms) will be added on issue #2222 to consolidate the information/history.

fixes #2222