### PR TITLE
Update quick start links as they're 404ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Please visit [http://gobuffalo.io](http://gobuffalo.io) for the latest documenta
 
 ### Quick Start
 
-- [Installation](http://gobuffalo.io/docs/installation)
-- [Create a new project](http://gobuffalo.io/docs/new-project)
-- [Examples](http://gobuffalo.io/docs/examples)
+- [Installation](https://gobuffalo.io/documentation/getting_started/installation)
+- [Create a new project](https://gobuffalo.io/documentation/getting_started/new-project)
+- [Tutorials](https://gobuffalo.io/documentation/tutorials/)
 
 ## Shoulders of Giants
 


### PR DESCRIPTION
👋  Noticed when taking a look at buffalo that the quick start links are 404ing 🙈 

Figured I'd update these as it's one of the first places a new user will click.