### PR TITLE
HTTPError Error() avoid nil pointer dereference on nil Cause

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,7 @@ func (h HTTPError) Unwrap() error {
 
 // Error returns the cause of the error as string.
 func (h HTTPError) Error() string {
-	return h.Cause.Error()
+	return fmt.Sprint(h.Cause)
 }
 
 // ErrorHandler interface for handling an error for a

--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,10 @@ func (h HTTPError) Unwrap() error {
 
 // Error returns the cause of the error as string.
 func (h HTTPError) Error() string {
-	return fmt.Sprint(h.Cause)
+	if h.Cause != nil {
+		return h.Cause.Error()
+	}
+	return "unknown cause"
 }
 
 // ErrorHandler interface for handling an error for a

--- a/errors_test.go
+++ b/errors_test.go
@@ -143,6 +143,18 @@ func Test_defaultErrorHandler_XML_production(t *testing.T) {
 	r.Contains(b, `</response>`)
 }
 
+func Test_defaultErrorHandler_nil_error(t *testing.T) {
+	r := require.New(t)
+	app := New(Options{})
+	app.GET("/", func(c Context) error {
+		return c.Error(http.StatusInternalServerError, nil)
+	})
+
+	w := httptest.New(app)
+	res := w.JSON("/").Get()
+	r.Equal(http.StatusInternalServerError, res.Code)
+}
+
 func Test_PanicHandler(t *testing.T) {
 	app := New(Options{})
 	app.GET("/string", func(c Context) error {


### PR DESCRIPTION
The default renderer `Error()` method does not check for a `nil` `error` on the underlying `HTTPError` type. A `nil pointer dereference` can be triggered by calling for example on the default renderer: `c.Render(500, nil)`.

This PR changes the `HTTPError` `Error()` method to use `fmt.Sprint()` instead of calling `Error()` on the underlying `error` in `Cause`.