### PR TITLE
added input/status checks, testcases, and comments for road-to-v1

### DIFF
--- a/worker/simple_test.go
+++ b/worker/simple_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -160,15 +161,21 @@ func Test_Simple_PerformAt(t *testing.T) {
 	w := NewSimple()
 	r.NoError(w.Start(context.Background()))
 
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
 	w.Register("x", func(Args) error {
 		hit = true
+		wg.Done()
 		return nil
 	})
 	w.PerformAt(Job{
 		Handler: "x",
 	}, time.Now().Add(5*time.Millisecond))
 
-	time.Sleep(10 * time.Millisecond)
+	// how long does the handler take for assignment? hmm,
+	time.Sleep(100 * time.Millisecond)
+	wg.Wait()
 	r.True(hit)
 
 	r.NoError(w.Stop())
@@ -181,15 +188,21 @@ func Test_Simple_PerformIn(t *testing.T) {
 	w := NewSimple()
 	r.NoError(w.Start(context.Background()))
 
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
 	w.Register("x", func(Args) error {
 		hit = true
+		wg.Done()
 		return nil
 	})
 	w.PerformIn(Job{
 		Handler: "x",
 	}, 5*time.Millisecond)
 
-	time.Sleep(10 * time.Millisecond)
+	// how long does the handler take for assignment? hmm,
+	time.Sleep(100 * time.Millisecond)
+	wg.Wait()
 	r.True(hit)
 
 	r.NoError(w.Stop())

--- a/worker/simple_test.go
+++ b/worker/simple_test.go
@@ -1,48 +1,85 @@
 package worker
 
 import (
-	"sync"
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+func sampleHandler(Args) error {
+	return nil
+}
+
+func Test_Simple_RegisterEmpty(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	err := w.Register("", sampleHandler)
+	r.Error(err)
+}
+
+func Test_Simple_RegisterNil(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	err := w.Register("sample", nil)
+	r.Error(err)
+}
+
+func Test_Simple_RegisterEmptyNil(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	err := w.Register("", nil)
+	r.Error(err)
+}
+
+func Test_Simple_RegisterExisting(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	err := w.Register("sample", sampleHandler)
+	r.NoError(err)
+
+	err = w.Register("sample", sampleHandler)
+	r.Error(err)
+}
+
+func Test_Simple_StartStop(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	ctx := context.Background()
+	err := w.Start(ctx)
+	r.NoError(err)
+	r.NotNil(w.ctx)
+	r.Nil(w.ctx.Err())
+
+	err = w.Stop()
+	r.NoError(err)
+	r.NotNil(w.ctx)
+	r.NotNil(w.ctx.Err())
+}
+
 func Test_Simple_Perform(t *testing.T) {
 	r := require.New(t)
 
 	var hit bool
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
 	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+
 	w.Register("x", func(Args) error {
 		hit = true
-		wg.Done()
 		return nil
 	})
 	w.Perform(Job{
 		Handler: "x",
 	})
-	wg.Wait()
-	r.True(hit)
-}
 
-func Test_Simple_PerformAt(t *testing.T) {
-	r := require.New(t)
-
-	var hit bool
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	w := NewSimple()
-	w.Register("x", func(Args) error {
-		hit = true
-		wg.Done()
-		return nil
-	})
-	w.PerformAt(Job{
-		Handler: "x",
-	}, time.Now().Add(5*time.Millisecond))
-	wg.Wait()
+	// the worker should guarantee the job is finished before the worker stopped
+	r.NoError(w.Stop())
 	r.True(hit)
 }
 
@@ -50,50 +87,160 @@ func Test_Simple_PerformBroken(t *testing.T) {
 	r := require.New(t)
 
 	var hit bool
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
 	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+
 	w.Register("x", func(Args) error {
 		hit = true
-		wg.Done()
 
 		//Index out of bounds on purpose
 		println([]string{}[0])
 
 		return nil
 	})
-
 	w.Perform(Job{
 		Handler: "x",
 	})
-	wg.Wait()
+
+	r.NoError(w.Stop())
 	r.True(hit)
+}
+
+func Test_Simple_PerformWithEmptyJob(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+	defer w.Stop()
+
+	err := w.Perform(Job{})
+	r.Error(err)
+}
+
+func Test_Simple_PerformWithUnknownJob(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+	defer w.Stop()
+
+	err := w.Perform(Job{Handler: "unknown"})
+	r.Error(err)
+}
+
+/* TODO(sio4): #road-to-v1 - define the purpose of Start clearly
+   consider to make Perform to work only when the worker is started.
+func Test_Simple_PerformBeforeStart(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	r.NoError(w.Register("sample", sampleHandler))
+
+	err := w.Perform(Job{Handler: "sample"})
+	r.Error(err)
+}
+*/
+
+func Test_Simple_PerformAfterStop(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	r.NoError(w.Register("sample", sampleHandler))
+	r.NoError(w.Start(context.Background()))
+	r.NoError(w.Stop())
+
+	err := w.Perform(Job{Handler: "sample"})
+	r.Error(err)
+}
+
+func Test_Simple_PerformAt(t *testing.T) {
+	r := require.New(t)
+
+	var hit bool
+	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+
+	w.Register("x", func(Args) error {
+		hit = true
+		return nil
+	})
+	w.PerformAt(Job{
+		Handler: "x",
+	}, time.Now().Add(5*time.Millisecond))
+
+	time.Sleep(10 * time.Millisecond)
+	r.True(hit)
+
+	r.NoError(w.Stop())
 }
 
 func Test_Simple_PerformIn(t *testing.T) {
 	r := require.New(t)
 
 	var hit bool
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
 	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+
 	w.Register("x", func(Args) error {
 		hit = true
-		wg.Done()
 		return nil
 	})
 	w.PerformIn(Job{
 		Handler: "x",
 	}, 5*time.Millisecond)
-	wg.Wait()
+
+	time.Sleep(10 * time.Millisecond)
 	r.True(hit)
+
+	r.NoError(w.Stop())
 }
 
-func Test_Simple_NoHandler(t *testing.T) {
+/* TODO(sio4): #road-to-v1 - define the purpose of Start clearly
+   consider to make Perform to work only when the worker is started.
+func Test_Simple_PerformInBeforeStart(t *testing.T) {
 	r := require.New(t)
 
 	w := NewSimple()
-	err := w.Perform(Job{})
+	r.NoError(w.Register("sample", sampleHandler))
+
+	err := w.PerformIn(Job{Handler: "sample"}, 5*time.Millisecond)
 	r.Error(err)
 }
+*/
+
+func Test_Simple_PerformInAfterStop(t *testing.T) {
+	r := require.New(t)
+
+	w := NewSimple()
+	r.NoError(w.Register("sample", sampleHandler))
+	r.NoError(w.Start(context.Background()))
+	r.NoError(w.Stop())
+
+	err := w.PerformIn(Job{Handler: "sample"}, 5*time.Millisecond)
+	r.Error(err)
+}
+
+/* TODO(sio4): #road-to-v1 - it should be guaranteed to be performed
+   consider to make PerformIn to guarantee the job execution
+func Test_Simple_PerformInFollowedByStop(t *testing.T) {
+	r := require.New(t)
+
+	var hit bool
+	w := NewSimple()
+	r.NoError(w.Start(context.Background()))
+
+	w.Register("x", func(Args) error {
+		hit = true
+		return nil
+	})
+	err := w.PerformIn(Job{
+		Handler: "x",
+	}, 5*time.Millisecond)
+	r.NoError(err)
+
+	// stop the worker immediately after PerformIn
+	r.NoError(w.Stop())
+
+	r.True(hit)
+}
+*/


### PR DESCRIPTION
Improved the simple worker:

* Added input/status checks for
  * `Register()`, if the name and handler are defined correctly
  * `Perform()` and `PerformIn()`, if the worker's context was already canceled to prevent job submission
* Added wait group count for delayed jobs (PerformIn)
* Added locking in `Stop()` to prevent job submission when stopping
* Added comments for the road-to-v1 (#2242)

(This PR was started for #2241)