### PR TITLE
Fix logging of where application is bound

### DIFF
--- a/server.go
+++ b/server.go
@@ -22,6 +22,8 @@ import (
 func (a *App) Serve(srvs ...servers.Server) error {
 	var wg sync.WaitGroup
 
+	a.Logger.Debug("starting application")
+
 	payload := events.Payload{
 		"app": a,
 	}
@@ -31,7 +33,6 @@ func (a *App) Serve(srvs ...servers.Server) error {
 		return err
 	}
 
-	// Add default server if necessary
 	if len(srvs) == 0 {
 		if strings.HasPrefix(a.Options.Addr, "unix:") {
 			tcp, err := servers.UnixSocket(a.Options.Addr[5:])
@@ -95,8 +96,7 @@ func (a *App) Serve(srvs ...servers.Server) error {
 
 	for _, s := range srvs {
 		s.SetAddr(a.Addr)
-		a.Logger.Infof("starting server of type %T at %s",
-			s, s.Addr())
+		a.Logger.Infof("starting %s", s)
 		wg.Add(1)
 		go func(s servers.Server) {
 			defer wg.Done()

--- a/server.go
+++ b/server.go
@@ -22,10 +22,6 @@ import (
 func (a *App) Serve(srvs ...servers.Server) error {
 	var wg sync.WaitGroup
 
-	// FIXME: this information is not correct.
-	// It needs to be fixed as we support multiple servers.
-	a.Logger.Infof("starting application at http://%s", a.Options.Addr)
-
 	payload := events.Payload{
 		"app": a,
 	}
@@ -35,6 +31,7 @@ func (a *App) Serve(srvs ...servers.Server) error {
 		return err
 	}
 
+	// Add default server if necessary
 	if len(srvs) == 0 {
 		if strings.HasPrefix(a.Options.Addr, "unix:") {
 			tcp, err := servers.UnixSocket(a.Options.Addr[5:])
@@ -98,6 +95,8 @@ func (a *App) Serve(srvs ...servers.Server) error {
 
 	for _, s := range srvs {
 		s.SetAddr(a.Addr)
+		a.Logger.Infof("starting server of type %T at %s",
+			s, s.Addr())
 		wg.Add(1)
 		go func(s servers.Server) {
 			defer wg.Done()

--- a/servers/listener.go
+++ b/servers/listener.go
@@ -19,6 +19,11 @@ func (s *Listener) SetAddr(addr string) {
 	}
 }
 
+// Addr gets the HTTP server address
+func (s *Listener) Addr() string {
+	return s.Server.Addr
+}
+
 // Start the server
 func (s *Listener) Start(c context.Context, h http.Handler) error {
 	s.Handler = h

--- a/servers/listener.go
+++ b/servers/listener.go
@@ -2,6 +2,7 @@ package servers
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 )
@@ -19,9 +20,9 @@ func (s *Listener) SetAddr(addr string) {
 	}
 }
 
-// Addr gets the HTTP server address
-func (s *Listener) Addr() string {
-	return s.Server.Addr
+// String returns a string representation of a Listener
+func (s *Listener) String() string {
+	return fmt.Sprintf("listener on %s", s.Server.Addr)
 }
 
 // Start the server

--- a/servers/servers.go
+++ b/servers/servers.go
@@ -8,6 +8,7 @@ import (
 
 // Server allows for custom server implementations
 type Server interface {
+	Addr() string
 	Shutdown(context.Context) error
 	Start(context.Context, http.Handler) error
 	SetAddr(string)

--- a/servers/servers.go
+++ b/servers/servers.go
@@ -8,7 +8,6 @@ import (
 
 // Server allows for custom server implementations
 type Server interface {
-	Addr() string
 	Shutdown(context.Context) error
 	Start(context.Context, http.Handler) error
 	SetAddr(string)

--- a/servers/simple.go
+++ b/servers/simple.go
@@ -17,6 +17,11 @@ func (s *Simple) SetAddr(addr string) {
 	}
 }
 
+// Addr gets the HTTP server address
+func (s *Simple) Addr() string {
+	return s.Server.Addr
+}
+
 // Start the server
 func (s *Simple) Start(c context.Context, h http.Handler) error {
 	s.Handler = h

--- a/servers/simple.go
+++ b/servers/simple.go
@@ -2,6 +2,7 @@ package servers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -17,9 +18,9 @@ func (s *Simple) SetAddr(addr string) {
 	}
 }
 
-// Addr gets the HTTP server address
-func (s *Simple) Addr() string {
-	return s.Server.Addr
+// String returns a string representation of a Simple server
+func (s *Simple) String() string {
+	return fmt.Sprintf("simple server on %s", s.Server.Addr)
 }
 
 // Start the server

--- a/servers/tls.go
+++ b/servers/tls.go
@@ -2,6 +2,7 @@ package servers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -19,9 +20,9 @@ func (s *TLS) SetAddr(addr string) {
 	}
 }
 
-// Addr gets the HTTP server address
-func (s *TLS) Addr() string {
-	return s.Server.Addr
+// String returns a string representation of a Listener
+func (s *TLS) String() string {
+	return fmt.Sprintf("TLS server on %s", s.Server.Addr)
 }
 
 // Start the server

--- a/servers/tls.go
+++ b/servers/tls.go
@@ -19,6 +19,11 @@ func (s *TLS) SetAddr(addr string) {
 	}
 }
 
+// Addr gets the HTTP server address
+func (s *TLS) Addr() string {
+	return s.Server.Addr
+}
+
 // Start the server
 func (s *TLS) Start(c context.Context, h http.Handler) error {
 	s.Handler = h


### PR DESCRIPTION
Addresses https://github.com/gobuffalo/buffalo/issues/2248

This adds a method to a public interface, which isn't ideal and may technically be a breaking change. I'm open to suggestions about that.