### PR TITLE
fix template based i18n support issues

### DIFF
--- a/render/template.go
+++ b/render/template.go
@@ -79,22 +79,8 @@ func (s *templateRenderer) updateAliases() error {
 			return nil
 		}
 
-		base := filepath.Base(path)
-		dir := filepath.Dir(path)
-
-		var exts []string
-		sep := strings.Split(base, ".")
-		if len(sep) >= 1 {
-			base = sep[0]
-		}
-		if len(sep) > 1 {
-			exts = sep[1:]
-		}
-
-		for _, ext := range exts {
-			pn := filepath.Join(dir, base+"."+ext)
-			s.aliases.Store(pn, path)
-		}
+		shortcut := strings.Replace(path, ".plush.", ".", 1)
+		s.aliases.Store(shortcut, path)
 
 		return nil
 	})

--- a/render/template_test.go
+++ b/render/template_test.go
@@ -220,3 +220,111 @@ func Test_Template_resolve_UserLang_Mixed(t *testing.T) {
 	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
 }
 
+// support short language-only version of template e.g. index.plush.ko.html
+func Test_Template_resolve_FullLocale_ShortFile(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.plush.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko-KR", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_LangOnly_FullFile(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.plush.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_FullLocale_ShortFile_Legacy(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.ko.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko-KR", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_LangOnly_FullFile_Legacy(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_FullLocale_ShortFile_Mixed(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko-KR", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_LangOnly_FullFile_Mixed(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}

--- a/render/template_test.go
+++ b/render/template_test.go
@@ -105,3 +105,118 @@ func Test_AssetPathNoManifestCorrupt(t *testing.T) {
 		r.NotEqual(expected, strings.TrimSpace(bb.String()))
 	}
 }
+
+/* test if i18n files (both with plush mid-extension and latecy) proceeded correctly.
+ */
+func Test_Template_resolve_DefaultLang_Plush(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.plush.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"es", "en"}}))
+	r.Equal("default Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_UserLang_Plush(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.plush.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko-KR", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_DefaultLang_Legacy(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"es", "en"}}))
+	r.Equal("default Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_UserLang_Legacy(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko-KR", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_DefaultLang_Mixed(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	// `buffalo fix` renames templates but does not fix actions
+	// in this case, aliases will be used for template matching
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"es", "en"}}))
+	r.Equal("default Paul", strings.TrimSpace(bb.String()))
+}
+
+func Test_Template_resolve_UserLang_Mixed(t *testing.T) {
+	r := require.New(t)
+
+	rootFS := memfs.New()
+	r.NoError(rootFS.WriteFile("index.plush.html", []byte("default <%= name %>"), 0644))
+	r.NoError(rootFS.WriteFile("index.plush.ko-kr.html", []byte("korean <%= name %>"), 0644))
+
+	e := NewEngine()
+	e.TemplatesFS = rootFS
+
+	// `buffalo fix` renames templates but does not fix actions
+	// in this case, aliases will be used for template matching
+	re := e.Template("foo/bar", "index.html")
+	r.Equal("foo/bar", re.ContentType())
+
+	bb := &bytes.Buffer{}
+	r.NoError(re.Render(bb, Data{"name": "Paul", "languages": []string{"ko-KR", "en"}}))
+	r.Equal("korean Paul", strings.TrimSpace(bb.String()))
+}
+


### PR DESCRIPTION
During upgrading my old app, I found some i18n features related to the templates were not working correctly. The issues are:

- When the `r.HTML(string)` stays with the old format, such as `r.HTML("index.html")`, but the template files are forms of `index.plush.html` and `index.plush.ko-kr.html` (renamed by `buffalo fix`), always the last file is used even though the browser's accept-language has no `ko` or `ko-KR`.
  - It happens because the logic of `templateRenderer.updateAliases()` does something unintended.
- Also, it is not a functional issue but `templateRenderer.resolve()` is called twice in many cases since `.localizedName()` uses this for checking if there is a template for possible languages.

#### Test environment

- template files:
  - `templates/index.plush.html`
  - `templates/index.plush.ko-kr.html`

**Debugging result when using `return c.Render(http.StatusOK, r.HTML("index.plush.html"))`**
--> OK, the correct templates are determined by the *direct name match*.

<details>

For ko-KR:

```
1. languages: [ko-KR ko en en-US en-US]
3. `index.plush.ko-kr.html`: try to resolve...
4. `index.plush.ko-kr.html` was **resolved directly** by the name
2. `index.plush.html` was localized as `index.plush.ko-kr.html`
3. `index.plush.ko-kr.html`: try to resolve...
4. `index.plush.ko-kr.html` was **resolved directly** by the name
3. `application.ko-kr.html`: try to resolve...
3. `application.ko.html`: try to resolve...
3. `application.en.html`: try to resolve...
2. `application.html` was localized as `application.html`
3. `application.html`: try to resolve...
5. `application.plush.html` was *resolved by map* for `application.html`
3. `_flash.html`: try to resolve...
5. `_flash.plush.html` was *resolved by map* for `_flash.html`
```

For the default language:
```
1. languages: [en en-US]
3. `index.plush.en.html`: try to resolve...
2. `index.plush.html` was localized as `index.plush.html`
3. `index.plush.html`: try to resolve...
4. `index.plush.html` was **resolved directly** by the name
3. `application.en.html`: try to resolve...
2. `application.html` was localized as `application.html`
3. `application.html`: try to resolve...
5. `application.plush.html` was *resolved by map* for `application.html`
3. `_flash.html`: try to resolve...
5. `_flash.plush.html` was *resolved by map* for `_flash.html`
```

</details>

**Debugging result when using `return c.Render(http.StatusOK, r.HTML("index.html"))`**
--> incorrect file is selected by *alias matching*.

<details>

For ko-KR
```
1. languages: [ko-KR ko en en-US en-US]
3. `index.ko-kr.html`: try to resolve...
3. `index.ko.html`: try to resolve...
3. `index.en.html`: try to resolve...
2. `index.html` was localized as `index.html`
3. `index.html`: try to resolve...
5. `index.plush.ko-kr.html` was *resolved by map* for `index.html`
3. `application.ko-kr.html`: try to resolve...
3. `application.ko.html`: try to resolve...
3. `application.en.html`: try to resolve...
2. `application.html` was localized as `application.html`
3. `application.html`: try to resolve...
5. `application.plush.html` was *resolved by map* for `application.html`
3. `_flash.html`: try to resolve...
5. `_flash.plush.html` was *resolved by map* for `_flash.html`
```

For the default language:
```
1. languages: [en en-US]
3. `index.en.html`: try to resolve...
2. `index.html` was localized as `index.html`
3. `index.html`: try to resolve...
5. `index.plush.ko-kr.html` was *resolved by map* for `index.html`
3. `application.en.html`: try to resolve...
2. `application.html` was localized as `application.html`
3. `application.html`: try to resolve...
5. `application.plush.html` was *resolved by map* for `application.html`
3. `_flash.html`: try to resolve...
5. `_flash.plush.html` was *resolved by map* for `_flash.html`
```

</details>

**Debugging result of the `updateAliases()`**: "which aliases are generated?"

```
   processing `index.plush.html` ...
     storing `index.plush.html` as `index.plush` (plush)
     storing `index.plush.html` as `index.html` (html`)
   processing `index.plush.ko-kr.html` ...
     storing `index.plush.ko-kr.html` as `index.plush` (plush)
     storing `index.plush.ko-kr.html` as `index.ko-kr (ko-kr)
     storing `index.plush.ko-kr.html` as `index.html` (html`)
```

As shown above, an unnecessary alias `index.ko-kr` is generated for the extension `ko-kr`, and the `index.html` and `index.plush` were overwritten by the last template every time and it became the default.

The first commit will fix this issue.

For the second issue, the calling time of `resolve()`, the original sequences are as follows:

when `ko-KR` is used for the request,
 
```
3. `index.plush.ko-kr.html`: try to resolve...
4. `index.plush.ko-kr.html` was **resolved directly** by the name
3. `index.plush.ko-kr.html`: try to resolve...
4. `index.plush.ko-kr.html` was **resolved directly** by the name
```

The template was evaluated twice. The second commit fixes this issue by introducing a new function `localizedResolve()`. The commit also improves the template-based i18n feature to support short language setting such as `ko` without the country code part, and also allows developers to create language-only templates such as `index.plush.ko.html` too.
