### PR TITLE
fixed racing condition of the simple worker

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -25,3 +25,15 @@ type Worker interface {
 	// Register a Handler
 	Register(string, Handler) error
 }
+
+/* TODO(sio4): #road-to-v1 - redefine Worker interface clearer
+1. The Start() functions of current implementations including Simple,
+   Gocraft Work Adapter do not block and immediately return the error.
+   However, App.Serve() calls them within a go routine.
+2. The Perform() family of functions can be called before the worker
+   was started once the worker configured. Could be fine but there should
+   be some guidiance for its usage.
+3. The Perform() function could be interpreted as "Do it" by its name but
+   their actual job is "Enqueue it" even though Simple worker has no clear
+   boundary between them. It could make confusion.
+*/


### PR DESCRIPTION
The new standard (reusable) testing workflow detected racing conditions on the buffalo core, and they were all in the Simple Worker. The root cause was basically:

- There are many goroutines that use a context, and the context reading/writing caused data race.
- Functions such as `PerformIn()` can be called while configuring the `App` and they use the default context.
- Worker is started by `Start(context)` with a new context when `App.Serve()` is called after the `App` setup was finished.

Additionally, the Worker spec is not clear enough for each function's purpose and expected actions. We need to revisit this when we design the next version. (#2242)

- The name of `Perform*()` is not clear. Their actual action should be enqueuing (not to perform the job by itself) even though the Simple Worker does perform the job.
- Need to define when the job submission (calling `Perform*()`) is allowed.
- ...

Anyway, this PR will fix the issue for now and will make the new testing works fine. (#2265)