### PR TITLE
safer error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ First, thank you so much for wanting to contribute! It means so much that you ca
 - Consider opening an issue **BEFORE** creating a Pull request (PR): you won't
   lose your time on fixing non-existing bugs, or fixing the wrong bug. Also we
   can help you to produce the best PR!
-- Open a PR against the `main` branch if your PR is for mainstrem or version
+- Open a PR against the `main` branch if your PR is for mainstream or version
   specific branch e.g. `v1` if your PR is for specific version.
   Note that the valid branch for a new feature request PR should be `main`
   while a PR against a version specific branch are allowed only for bugfixes.

--- a/errors.go
+++ b/errors.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strings"
 
-
 	"github.com/gobuffalo/buffalo/internal/defaults"
 	"github.com/gobuffalo/buffalo/internal/httpx"
 	"github.com/gobuffalo/events"

--- a/errors.go
+++ b/errors.go
@@ -11,10 +11,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gobuffalo/buffalo/internal/defaults"
-	"github.com/gobuffalo/buffalo/internal/httpx"
 	"github.com/gobuffalo/events"
 	"github.com/gobuffalo/plush/v4"
+
+	"github.com/gobuffalo/buffalo/internal/defaults"
+	"github.com/gobuffalo/buffalo/internal/httpx"
 )
 
 // HTTPError a typed error returned by http Handlers and used for choosing error handlers
@@ -174,7 +175,7 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 	c.Logger().Error(origErr)
 	c.Response().WriteHeader(status)
 
-	if env != nil && env.(string) == "production" {
+	if env != nil && env.(string) != "development" {
 		switch strings.ToLower(requestCT) {
 		case "application/json", "text/json", "json", "application/xml", "text/xml", "xml":
 			defaultErrorResponse = &ErrorResponse{

--- a/errors.go
+++ b/errors.go
@@ -11,11 +11,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gobuffalo/events"
-	"github.com/gobuffalo/plush/v4"
 
 	"github.com/gobuffalo/buffalo/internal/defaults"
 	"github.com/gobuffalo/buffalo/internal/httpx"
+	"github.com/gobuffalo/events"
+	"github.com/gobuffalo/plush/v4"
 )
 
 // HTTPError a typed error returned by http Handlers and used for choosing error handlers


### PR DESCRIPTION
The `defaultErrorHandler` presently compares the environment against "production" to determine whether it's safe to dump debugging details. When running in staging (or qa, etc.), it is preferable to not have debugging detail since it could be hosted on a public server. This PR reverses the logic so the detailed error message is only used when the environment is "development".