### PR TITLE
added detailed comment for render.Download()

### DIFF
--- a/render/download.go
+++ b/render/download.go
@@ -54,6 +54,14 @@ func (r downloadRenderer) Render(w io.Writer, d Data) error {
 //
 // Content-Type is set using mime#TypeByExtension with the filename's extension. Content-Type will default to
 // application/octet-stream if using a filename with an unknown extension.
+//
+// Note: the purpose of this function is not serving static files but to support
+// downloading of dynamically genrated data as a file. For example, you can use
+// this function when you implement CSV file download feature for the result of
+// a database query.
+//
+// Do not use this function for large io.Reader. It could cause out of memory if
+// the size of io.Reader is too big.
 func Download(ctx context.Context, name string, r io.Reader) Renderer {
 	return downloadRenderer{
 		ctx:    ctx,
@@ -70,6 +78,14 @@ func Download(ctx context.Context, name string, r io.Reader) Renderer {
 //
 // Content-Type is set using mime#TypeByExtension with the filename's extension. Content-Type will default to
 // application/octet-stream if using a filename with an unknown extension.
+//
+// Note: the purpose of this method is not serving static files but to support
+// downloading of dynamically genrated data as a file. For example, you can use
+// this method when you implement CSV file download feature for the result of
+// a database query.
+//
+// Do not use this method for large io.Reader. It could cause out of memory if
+// the size of io.Reader is too big.
 func (e *Engine) Download(ctx context.Context, name string, r io.Reader) Renderer {
 	return Download(ctx, name, r)
 }


### PR DESCRIPTION
Added a detailed comment for the `render.Download()`. This function/method is not for a static file but it should be used for dynamically generated file download for dynamic data. (e.g. CVS for database query)


fixes #2287