### PR TITLE
Piti/feat/trace on dev test

### DIFF
--- a/default_context.go
+++ b/default_context.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	pkgError "github.com/pkg/errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -196,7 +197,7 @@ func (d *DefaultContext) LogFields(values map[string]interface{}) {
 }
 
 func (d *DefaultContext) Error(status int, err error) error {
-	return HTTPError{Status: status, Cause: err}
+	return HTTPError{Status: status, Cause: pkgError.WithStack(err)}
 }
 
 var mapType = reflect.ValueOf(map[string]interface{}{}).Type()

--- a/errors.go
+++ b/errors.go
@@ -247,7 +247,9 @@ func defaultErrorHandler(status int, origErr error, c Context) error {
 	default:
 		c.Response().Header().Set("content-type", defaultErrorCT)
 		if err := c.Request().ParseForm(); err != nil {
-			trace = fmt.Sprintf("%s\n%s", err.Error(), trace)
+			trace = fmt.Sprintf("%s\n%s\n%s", err.Error(), origErr.Error(), trace)
+		} else {
+			trace = fmt.Sprintf("%s\n%s", origErr.Error(), trace)
 		}
 
 		routes := c.Value("routes")

--- a/errors_test.go
+++ b/errors_test.go
@@ -3,7 +3,6 @@ package buffalo
 import (
 	errors "errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"testing"
@@ -119,7 +118,6 @@ func testDefaultErrorHandler(t *testing.T, contentType, env string) {
 	r.Equal(contentType, ct)
 	b := res.Body.String()
 	isDevOrTest := env == "development" || env == "test"
-	log.Printf(b)
 	if isDevOrTest {
 		if contentType == "text/xml" {
 			r.Contains(b, `<response code="401">`)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1
 	github.com/monoculum/formam v3.5.5+incompatible
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/monoculum/formam v3.5.5+incompatible h1:iPl5csfEN96G2N2mGu8V/ZB62XLf9ySTpC8KRH6qXec=
 github.com/monoculum/formam v3.5.5+incompatible/go.mod h1:RKgILGEJq24YyJ2ban8EO0RUVSJlF1pGsEvoLEACr/Q=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef h1:NKxTG6GVGbfMXc2mIk+KphcH6hagbVXhcFkbTgYleTI=


### PR DESCRIPTION
### What is being done in this PR?

This PR fixes issue #1904. And fix the bug caused by one of the previous pr that trace will only appear on development but not test environment.


### What are the main choices made to get to this solution?

Without traces it's much harder to debug. The doc is also misleading that we will get a trace but in fact we didn't. This PR fix that issue.

https://gobuffalo.io/documentation/request_handling/errors/#default-error-handling-development

### List the manual test cases you've covered before sending this PR:

The tests are covered in unit tests.

On dev, test: when handler return error being (pkg/errors or context.Error()) if it contains stack trace then it should return that stack trace.
On other env, trace is hidden.