### PR TITLE
enabled stack trace when the original error support it (in dev and event)

### DIFF
--- a/error.dev.html
+++ b/error.dev.html
@@ -496,11 +496,12 @@
 
         table.table tbody tr td {
             border-top: 0;
-            padding: 10px
+            border-bottom: 1px dotted #ddd;
+            padding: 2px;
         }
 
         pre {
-            white-space: pre-line;
+            white-space: pre-wrap;
             margin-bottom: 10px;
             max-height: 275px;
             overflow: scroll


### PR DESCRIPTION
### What is being done in this PR?

* enabled stack trace in the error page in development mode
* enabled stack trace in error event from the default error middleware

### What are the main choices made to get to this solution?

Previously, we deprecated support of `errors.WithStack()` from `pkg/errors` to reduce dependencies, because that is only useful when the user application supports it and is mostly useless or just verbose. Now, the fix just uses the format verb `%+v` to support it, and it can support the others if they support the verb too. Flexible, and no additional dependency.

### The result of the fix

The routing error causes 404 and we don't need a trace for that. It is clear enough.

```console
$ curl -H 'Content-Type: application/json' 'http://localhost:3000/unknown'
{"error":"could not find unknown","trace":"could not find unknown","code":404}
```

404 by database missing also clear enough, we don't care 4xx errors.

```console
$ curl -H 'Content-Type: application/json' http://localhost:3000/name_othernames/e60c7e01/
{"error":"sqlite select one: sql: no rows in result set","trace":"sqlite select one: sql: no rows in result set","code":404}
```

We cannot get the stack if the user's handler just returned a simple error something like `return fmt.Errorf("internal error")`.

```console
$ curl -H 'Content-Type: application/json' 'http://localhost:3000/error'
{"error":"internal error","trace":"internal error","code":500}
```

When the user's handler returned an error support `%+v`, like `return errors.New("internal error")` with `pkg/errors`, we can see the stack trace.

```console
$ curl -H 'Content-Type: application/json' 'http://localhost:3000/pkgerror'
{"error":"internal error","trace":"internal error\ncoco/actions.pkgErrorFunc\n\t/home/sio4/git/bt/coco/actions/app.go:157\ncoco/actions.App.func1.6\n\t/home/sio4/git/bt/coco/actions/app.go:99\ngithub.com/gobuffalo/buffalo.assertMiddleware.func1...
```


Related PRs:
[1] #138
[2] #1643
[3] #1930
[4] #2352

fixes #1904
obsoletes #2358