### PR TITLE
fix URL Prefix

### DIFF
--- a/app.go
+++ b/app.go
@@ -56,7 +56,9 @@ func New(opts Options) *App {
 		routes:   RouteList{},
 		children: []*App{},
 
-		RouteNamer: baseRouteNamer{},
+		RouteNamer: baseRouteNamer{
+			Prefix: opts.Prefix,
+		},
 	}
 	a.Home.app = a     // replace root.
 	a.Home.appSelf = a // temporary, reverse reference to the group app.

--- a/routenamer.go
+++ b/routenamer.go
@@ -17,10 +17,12 @@ type RouteNamer interface {
 }
 
 // BaseRouteNamer is the default route namer used by apps.
-type baseRouteNamer struct{}
+type baseRouteNamer struct {
+	Prefix string
+}
 
 func (drn baseRouteNamer) NameRoute(p string) string {
-	if p == "/" || p == "" {
+	if p == drn.Prefix || p == "/" || p == "" {
 		return "root"
 	}
 


### PR DESCRIPTION
This PR addresses Issue #2356. 

### What is being done in this PR?
> Type in here a description of the changes in this PR. 
The web console cannot be opened after setting a URL prefix in `actions/app.go` :
```go
	appOnce.Do(func() {
		app = buffalo.New(buffalo.Options{
			Env:         ENV,
			SessionName: "_prefix_test_session",
			Prefix:      "/prefix/",
		})

```
The error is : 
```
home/index.plush.html: line 5: "rootPath": unknown identifier
```

### What are the main choices made to get to this solution?
> Type in here a description of the choices made to get to this solution.

`routenamer.go` consider's "/" as the root path only, ignoring a URL prefix as a root path.



### List the manual test cases you've covered before sending this PR:
1. Add a prefix as above then open `http://127.0.0.1:3000/prefix/` in the browser.