### PR TITLE
Fix URL prefix

### DIFF
--- a/app.go
+++ b/app.go
@@ -56,7 +56,9 @@ func New(opts Options) *App {
 		routes:   RouteList{},
 		children: []*App{},
 
-		RouteNamer: baseRouteNamer{},
+		RouteNamer: baseRouteNamer{
+			Prefix: opts.Prefix,
+		},
 	}
 	a.Home.app = a     // replace root.
 	a.Home.appSelf = a // temporary, reverse reference to the group app.

--- a/render/options.go
+++ b/render/options.go
@@ -32,4 +32,7 @@ type Options struct {
 	// DefaultContentType instructs the engine what it should fall back to if
 	// the "content-type" is unknown
 	DefaultContentType string
+
+	// Prefix inherits the global single prefix from buffalo.Options
+	Prefix string
 }

--- a/render/template.go
+++ b/render/template.go
@@ -266,18 +266,18 @@ func (s *templateRenderer) assetPath(file string) (string, error) {
 		if err != nil {
 			manifest, err = s.AssetsFS.Open("assets/manifest.json")
 			if err != nil {
-				return assetPathFor(file), nil
+				return assetPathFor(s.Prefix, file), nil
 			}
 		}
 		defer manifest.Close()
 
 		err = loadManifest(manifest)
 		if err != nil {
-			return assetPathFor(file), fmt.Errorf("your manifest.json is not correct: %s", err)
+			return assetPathFor(s.Prefix, file), fmt.Errorf("your manifest.json is not correct: %s", err)
 		}
 	}
 
-	return assetPathFor(file), nil
+	return assetPathFor(s.Prefix, file), nil
 }
 
 // Template renders the named files using the specified

--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -45,12 +45,12 @@ func (s *templateRenderer) addAssetsHelpers(helpers Helpers) Helpers {
 
 var assetMap = stringMap{}
 
-func assetPathFor(file string) string {
+func assetPathFor(prefix string, file string) string {
 	filePath, ok := assetMap.Load(file)
 	if filePath == "" || !ok {
 		filePath = file
 	}
-	return path.Join("/assets", filePath)
+	return path.Join(prefix, "/assets", filePath)
 }
 
 func loadManifest(manifest io.Reader) error {

--- a/routenamer.go
+++ b/routenamer.go
@@ -17,9 +17,15 @@ type RouteNamer interface {
 }
 
 // BaseRouteNamer is the default route namer used by apps.
-type baseRouteNamer struct{}
+type baseRouteNamer struct {
+	Prefix string
+}
 
 func (drn baseRouteNamer) NameRoute(p string) string {
+	if drn.Prefix != "" {
+		p = strings.TrimPrefix(p, drn.Prefix)
+	}
+
 	if p == "/" || p == "" {
 		return "root"
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -746,8 +746,8 @@ func Test_buildRouteName(t *testing.T) {
 
 	a = New(Options{Prefix: "/test"})
 	cases = map[string]string{
-		"/test":       "test",
-		"/test/users": "testUsers",
+		"/test":       "root",
+		"/test/users": "users",
 	}
 
 	for input, result := range cases {

--- a/router_test.go
+++ b/router_test.go
@@ -581,6 +581,27 @@ func Test_Resource_ParamKey(t *testing.T) {
 	r.Contains(paths, "/foo/{bazKey}/edit/")
 }
 
+func Test_RouteNameWithPrefix(t *testing.T) {
+	r := require.New(t)
+	cases := map[string]string{
+		"/":          "root",
+		"/users":     "users",
+		"/users/new": "newUsers",
+	}
+
+	a := New(Options{Prefix: ""})
+	for input, expected := range cases {
+		actual := a.RouteNamer.NameRoute(input)
+		r.Equal(expected, actual, input)
+	}
+
+	a = New(Options{Prefix: "/prefix"})
+	for input, expected := range cases {
+		actual := a.RouteNamer.NameRoute(input)
+		r.Equal(expected, actual, input)
+	}
+}
+
 type mwResource struct {
 	WebResource
 }


### PR DESCRIPTION
This PR addresses Issue #2356. 

### What is being done in this PR?
> Type in here a description of the changes in this PR. 
The web console cannot be opened after setting a URL prefix in `actions/app.go` :
```go
	appOnce.Do(func() {
		app = buffalo.New(buffalo.Options{
			Env:         ENV,
			SessionName: "_prefix_test_session",
			Prefix:      "/prefix/",
		})

```
The error is : 
```
home/index.plush.html: line 5: "rootPath": unknown identifier
```

### What are the main choices made to get to this solution?
> Type in here a description of the choices made to get to this solution.

`routenamer.go` considers "/" as the root path only, ignoring a URL prefix as a root path.



### List the manual test cases you've covered before sending this PR:
1. Add a prefix as above then open `http://127.0.0.1:3000/prefix/` in the browser.