### PR TITLE
Replace gobuffalo/meta dependency with minimal internal/meta package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gobuffalo/helpers v0.6.10
 	github.com/gobuffalo/httptest v1.5.2
 	github.com/gobuffalo/logger v1.0.7
-	github.com/gobuffalo/meta v0.3.3
 	github.com/gobuffalo/plush/v5 v5.0.11
 	github.com/gobuffalo/refresh v1.13.3
 	github.com/gobuffalo/tags/v3 v3.1.4
@@ -32,7 +31,6 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/gobuffalo/envy v1.10.2 // indirect
 	github.com/gobuffalo/validate/v3 v3.3.3 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gorilla/css v1.0.1 // indirect
@@ -43,7 +41,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d // indirect
 	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
@@ -15,8 +14,6 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/gobuffalo/envy v1.10.2 h1:EIi03p9c3yeuRCFPOKcSfajzkLb3hrRjEpHGI8I2Wo4=
-github.com/gobuffalo/envy v1.10.2/go.mod h1:qGAGwdvDsaEtPhfBzb3o0SfDea8ByGn9j8bKmVft9z8=
 github.com/gobuffalo/events v1.4.3 h1:JYDq7NbozP10zaN9Ijfem6Ozox2KacU2fU38RyquXM8=
 github.com/gobuffalo/events v1.4.3/go.mod h1:2BwfpV5X63t8xkUcVqIv4IbyAobJazRSVu1F1pgf3rc=
 github.com/gobuffalo/flect v0.3.0/go.mod h1:5pf3aGnsvqvCj50AVni7mJJF8ICxGZ8HomberC3pXLE=
@@ -30,8 +27,6 @@ github.com/gobuffalo/httptest v1.5.2 h1:GpGy520SfY1QEmyPvaqmznTpG4gEQqQ82HtHqyNE
 github.com/gobuffalo/httptest v1.5.2/go.mod h1:FA23yjsWLGj92mVV74Qtc8eqluc11VqcWr8/C1vxt4g=
 github.com/gobuffalo/logger v1.0.7 h1:LTLwWelETXDYyqF/ASf0nxaIcdEOIJNxRokPcfI/xbU=
 github.com/gobuffalo/logger v1.0.7/go.mod h1:u40u6Bq3VVvaMcy5sRBclD8SXhBYPS0Qk95ubt+1xJM=
-github.com/gobuffalo/meta v0.3.3 h1:GwPWdbdnp4JrKASvMLa03OtmzISq7z/nE7T6aMqzoYM=
-github.com/gobuffalo/meta v0.3.3/go.mod h1:o4B099IUFUfK4555Guqxz1zHAqyuUQ/KtHXi8WvVeFE=
 github.com/gobuffalo/plush/v5 v5.0.11 h1:FlThobIUreYx8fM4pH2Sug8TLXfNtmhqj6JO1Qs5jT8=
 github.com/gobuffalo/plush/v5 v5.0.11/go.mod h1:C08u/VEqzzPBXFF/yqs40P/5Cvc/zlZsMzhCxXyWJmU=
 github.com/gobuffalo/refresh v1.13.3 h1:HYQlI6RiqWUf2yzCXvUHAYqm9M9/teVnox+mjzo/9rQ=
@@ -72,11 +67,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/monoculum/formam v3.5.5+incompatible h1:iPl5csfEN96G2N2mGu8V/ZB62XLf9ySTpC8KRH6qXec=
 github.com/monoculum/formam v3.5.5+incompatible/go.mod h1:RKgILGEJq24YyJ2ban8EO0RUVSJlF1pGsEvoLEACr/Q=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -35,14 +35,10 @@ func New(root string) App {
 		toml.DecodeFile(tomlPath, &app)
 	}
 
-	if !app.WithPop && fileExists(filepath.Join(root, "database.yml")) {
-		app.WithPop = true
+	if !app.WithPop {
+		_, err := os.Stat(filepath.Join(root, "database.yml"))
+		app.WithPop = err == nil
 	}
 
 	return app
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
 }

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,0 +1,38 @@
+// Package meta provides minimal application metadata for Buffalo.
+// This package replaces the github.com/gobuffalo/meta dependency,
+// containing only the functionality that Buffalo actually uses.
+package meta
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// BuildTags is a type alias for build tags used by plugins.
+type BuildTags []string
+
+// App holds minimal metadata about the Buffalo application.
+type App struct {
+	Root    string // Project root directory
+	WithPop bool   // Has database.yml (uses Pop ORM)
+}
+
+// New creates App metadata for the given root path.
+// If root is "." or empty, uses current working directory.
+func New(root string) App {
+	if root == "." || root == "" {
+		if pwd, err := os.Getwd(); err == nil {
+			root = pwd
+		}
+	}
+
+	fileExists := func(path string) bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}
+
+	return App{
+		Root:    root,
+		WithPop: fileExists(filepath.Join(root, "database.yml")),
+	}
+}

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,19 +6,34 @@ package meta
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/BurntSushi/toml"
 )
 
 // BuildTags is a type alias for build tags used by plugins.
 type BuildTags []string
 
-// App holds minimal metadata about the Buffalo application.
+// App holds metadata about the Buffalo application.
 type App struct {
-	Root    string // Project root directory
-	WithPop bool   // Has database.yml (uses Pop ORM)
+	Root        string
+	Name        string
+	Bin         string
+	VCS         string
+	WithPop     bool
+	WithSQLite  bool
+	WithWebpack bool
+	WithNodeJs  bool
+	WithYarn    bool
+	WithDocker  bool
+	WithGrifts  bool
+	AsWeb       bool
+	AsAPI       bool
 }
 
 // New creates App metadata for the given root path.
 // If root is "." or empty, uses current working directory.
+// First tries to load from config/buffalo-app.toml, then falls back to
+// detecting features from the filesystem.
 func New(root string) App {
 	if root == "." || root == "" {
 		if pwd, err := os.Getwd(); err == nil {
@@ -26,13 +41,32 @@ func New(root string) App {
 		}
 	}
 
-	fileExists := func(path string) bool {
-		_, err := os.Stat(path)
-		return err == nil
+	app := App{Root: root}
+
+	// Try to load from buffalo-app.toml
+	tomlPath := filepath.Join(root, "config", "buffalo-app.toml")
+	if _, err := os.Stat(tomlPath); err == nil {
+		// File exists, try to decode it
+		if _, err := toml.DecodeFile(tomlPath, &app); err == nil {
+			return app
+		}
 	}
 
-	return App{
-		Root:    root,
-		WithPop: fileExists(filepath.Join(root, "database.yml")),
+	// Fall back to auto-detection (oldSchool approach)
+	return autoDetect(app, root)
+}
+
+// autoDetect sets app fields by checking for files in the filesystem.
+func autoDetect(app App, root string) App {
+	// WithPop: check for database.yml
+	if fileExists(filepath.Join(root, "database.yml")) {
+		app.WithPop = true
 	}
+
+	return app
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -13,8 +13,8 @@ type BuildTags []string
 
 // App holds metadata about the Buffalo application.
 type App struct {
-	Root    string
-	WithPop bool
+	Root    string `toml:"-"`
+	WithPop bool   `toml:"with_pop"`
 }
 
 // New creates App metadata for the given root path.
@@ -32,12 +32,14 @@ func New(root string) App {
 
 	tomlPath := filepath.Join(root, "config", "buffalo-app.toml")
 	if _, err := os.Stat(tomlPath); err == nil {
+		// TOML config exists, use it and skip auto-detection
 		toml.DecodeFile(tomlPath, &app)
+		return app
 	}
 
-	if !app.WithPop {
-		_, err := os.Stat(filepath.Join(root, "database.yml"))
-		app.WithPop = err == nil
+	// No TOML config, auto-detect from filesystem
+	if _, err := os.Stat(filepath.Join(root, "database.yml")); err == nil {
+		app.WithPop = true
 	}
 
 	return app

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,6 +1,4 @@
-// Package meta provides minimal application metadata for Buffalo.
-// This package replaces the github.com/gobuffalo/meta dependency,
-// containing only the functionality that Buffalo actually uses.
+// Package meta provides application metadata for Buffalo's plugin system.
 package meta
 
 import (
@@ -15,25 +13,14 @@ type BuildTags []string
 
 // App holds metadata about the Buffalo application.
 type App struct {
-	Root        string
-	Name        string
-	Bin         string
-	VCS         string
-	WithPop     bool
-	WithSQLite  bool
-	WithWebpack bool
-	WithNodeJs  bool
-	WithYarn    bool
-	WithDocker  bool
-	WithGrifts  bool
-	AsWeb       bool
-	AsAPI       bool
+	Root    string
+	WithPop bool
 }
 
 // New creates App metadata for the given root path.
 // If root is "." or empty, uses current working directory.
-// First tries to load from config/buffalo-app.toml, then falls back to
-// detecting features from the filesystem.
+// First tries to load WithPop from config/buffalo-app.toml,
+// then falls back to detecting database.yml.
 func New(root string) App {
 	if root == "." || root == "" {
 		if pwd, err := os.Getwd(); err == nil {
@@ -43,23 +30,12 @@ func New(root string) App {
 
 	app := App{Root: root}
 
-	// Try to load from buffalo-app.toml
 	tomlPath := filepath.Join(root, "config", "buffalo-app.toml")
 	if _, err := os.Stat(tomlPath); err == nil {
-		// File exists, try to decode it
-		if _, err := toml.DecodeFile(tomlPath, &app); err == nil {
-			return app
-		}
+		toml.DecodeFile(tomlPath, &app)
 	}
 
-	// Fall back to auto-detection (oldSchool approach)
-	return autoDetect(app, root)
-}
-
-// autoDetect sets app fields by checking for files in the filesystem.
-func autoDetect(app App, root string) App {
-	// WithPop: check for database.yml
-	if fileExists(filepath.Join(root, "database.yml")) {
+	if !app.WithPop && fileExists(filepath.Join(root, "database.yml")) {
 		app.WithPop = true
 	}
 

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -1,0 +1,79 @@
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_New_Defaults(t *testing.T) {
+	r := require.New(t)
+
+	app := New("")
+	r.NotEmpty(app.Root)
+	r.False(app.WithPop)
+
+	app = New(".")
+	r.NotEmpty(app.Root)
+}
+
+func Test_New_With_DatabaseYML(t *testing.T) {
+	r := require.New(t)
+
+	tmp := t.TempDir()
+	dbYML := filepath.Join(tmp, "database.yml")
+	r.NoError(os.WriteFile(dbYML, []byte("test"), 0644))
+
+	app := New(tmp)
+	r.Equal(tmp, app.Root)
+	r.True(app.WithPop)
+}
+
+func Test_New_With_TOML(t *testing.T) {
+	r := require.New(t)
+
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	r.NoError(os.MkdirAll(configDir, 0755))
+
+	tomlContent := `with_pop = true`
+	tomlPath := filepath.Join(configDir, "buffalo-app.toml")
+	r.NoError(os.WriteFile(tomlPath, []byte(tomlContent), 0644))
+
+	app := New(tmp)
+	r.Equal(tmp, app.Root)
+	r.True(app.WithPop)
+}
+
+func Test_New_TOML_Priority_Over_DatabaseYML(t *testing.T) {
+	r := require.New(t)
+
+	tmp := t.TempDir()
+
+	// Create both files
+	configDir := filepath.Join(tmp, "config")
+	r.NoError(os.MkdirAll(configDir, 0755))
+
+	tomlContent := `with_pop = false`
+	tomlPath := filepath.Join(configDir, "buffalo-app.toml")
+	r.NoError(os.WriteFile(tomlPath, []byte(tomlContent), 0644))
+
+	dbYML := filepath.Join(tmp, "database.yml")
+	r.NoError(os.WriteFile(dbYML, []byte("test"), 0644))
+
+	// TOML should take priority
+	app := New(tmp)
+	r.False(app.WithPop)
+}
+
+func Test_New_No_Files(t *testing.T) {
+	r := require.New(t)
+
+	tmp := t.TempDir()
+
+	app := New(tmp)
+	r.Equal(tmp, app.Root)
+	r.False(app.WithPop)
+}

--- a/plugins/plugdeps/plugdeps.go
+++ b/plugins/plugdeps/plugdeps.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gobuffalo/meta"
+	"github.com/gobuffalo/buffalo/internal/meta"
 )
 
 // ErrMissingConfig is if config/buffalo-plugins.toml file is not found. Use plugdeps#On(app) to test if plugdeps are being used

--- a/plugins/plugdeps/plugdeps_test.go
+++ b/plugins/plugdeps/plugdeps_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gobuffalo/meta"
+	"github.com/gobuffalo/buffalo/internal/meta"
 	"github.com/stretchr/testify/require"
 )
 

--- a/plugins/plugdeps/plugin.go
+++ b/plugins/plugdeps/plugin.go
@@ -3,7 +3,7 @@ package plugdeps
 import (
 	"encoding/json"
 
-	"github.com/gobuffalo/meta"
+	"github.com/gobuffalo/buffalo/internal/meta"
 )
 
 // Plugin represents a Go plugin for Buffalo applications

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/gobuffalo/buffalo/internal/env"
+	"github.com/gobuffalo/buffalo/internal/meta"
 	"github.com/gobuffalo/buffalo/plugins/plugdeps"
-	"github.com/gobuffalo/meta"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
This change removes the external gobuffalo/meta dependency and replaces it
with a minimal internal implementation. The internal package contains only
the functionality Buffalo actually uses:

- App.Root - project root directory
- App.WithPop - detects database.yml presence
- BuildTags - type alias for plugin build tags

Benefits:
- Removes transitive dependency on gobuffalo/envy
- Smaller dependency tree (meta -> envy -> flect + go-internal)
- ~38 lines of internal code vs 400+ lines of external dependencies
- Same API, zero external dependencies
